### PR TITLE
fix(notice): 홈/공지목록에 레거시 scope 화이트리스트 적용 — 영업사원(판매전략실) 공지 제외

### DIFF
--- a/backend/src/main/kotlin/com/otoki/powersales/notice/repository/NoticeRepositoryCustomImpl.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/notice/repository/NoticeRepositoryCustomImpl.kt
@@ -2,6 +2,7 @@ package com.otoki.powersales.notice.repository
 
 import com.otoki.powersales.notice.entity.Notice
 import com.otoki.powersales.notice.enums.NoticeCategory
+import com.otoki.powersales.notice.enums.NoticeScope
 import com.otoki.powersales.notice.entity.QNotice.Companion.notice
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.types.Predicate
@@ -21,6 +22,7 @@ class NoticeRepositoryCustomImpl(
     ): Page<Notice> {
         val where = BooleanBuilder()
             .and(buildDeletedCondition())
+            .and(buildScopeCondition())
             .and(buildCategoryCondition(category, branch))
             .and(buildSearchCondition(search))
 
@@ -81,6 +83,7 @@ class NoticeRepositoryCustomImpl(
             .selectFrom(notice)
             .where(
                 buildDeletedCondition(),
+                buildScopeCondition(),
                 notice.category.eq(NoticeCategory.COMPANY)
                     .or(notice.category.eq(NoticeCategory.BRANCH).and(notice.branch.eq(branch)))
                     .or(notice.category.eq(NoticeCategory.EDUCATION))
@@ -92,6 +95,20 @@ class NoticeRepositoryCustomImpl(
 
     private fun buildDeletedCondition(): Predicate {
         return notice.isDeleted.isNull.or(notice.isDeleted.eq(false))
+    }
+
+    /**
+     * 공개범위(scope) 노출 조건 — 레거시 `communityMapper.xml#selectNotice` 의
+     * `AND (dkretail__scope__c = '전체' OR dkretail__scope__c = '현장여사원')` 재현.
+     *
+     * 레거시는 scope 화이트리스트('전체' + '현장여사원')로 '영업사원' 공지를 홈/목록에서 제외한다
+     * (예: 【판매전략실】 공지는 scope='영업사원'). 신규 SF 피크리스트 `DKRetail__Scope__c` 는
+     * `영업사원`/`현장여사원` 2값만 존재하며 '전체' 는 레거시 UI 상수일 뿐 실데이터에 없으므로,
+     * "영업사원 제외"(= scope IS NULL OR scope = 현장여사원) 로 변환한다.
+     * null scope(미지정/구 '전체' 잔재)는 레거시 '전체' 의도에 맞춰 노출 유지.
+     */
+    private fun buildScopeCondition(): Predicate {
+        return notice.scope.isNull.or(notice.scope.ne(NoticeScope.SALES_EMPLOYEE))
     }
 
     private fun buildAdminCategoryCondition(category: NoticeCategory?): Predicate? {

--- a/backend/src/test/kotlin/com/otoki/powersales/notice/repository/NoticeRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/otoki/powersales/notice/repository/NoticeRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.otoki.powersales.notice.repository
 import com.otoki.powersales.common.config.QueryDslConfig
 import com.otoki.powersales.notice.entity.Notice
 import com.otoki.powersales.notice.enums.NoticeCategory
+import com.otoki.powersales.notice.enums.NoticeScope
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -45,6 +46,7 @@ class NoticeRepositoryTest {
         branch: String? = null,
         contents: String? = null,
         isDeleted: Boolean? = null,
+        scope: NoticeScope? = null,
         createdDate: LocalDateTime? = LocalDateTime.now()
     ): Notice {
         val notice = Notice(
@@ -52,7 +54,8 @@ class NoticeRepositoryTest {
             category = category,
             branch = branch,
             contents = contents,
-            isDeleted = isDeleted
+            isDeleted = isDeleted,
+            scope = scope
         )
         val persisted = testEntityManager.persistAndFlush(notice)
         if (createdDate != null) {
@@ -177,6 +180,22 @@ class NoticeRepositoryTest {
 
             // Then
             assertThat(result).isEmpty()
+        }
+
+        @Test
+        @DisplayName("영업사원 공개범위 공지(예: 판매전략실)는 제외된다 - 레거시 scope 화이트리스트")
+        fun excludesSalesEmployeeScope() {
+            // Given
+            val now = LocalDateTime.now()
+            persistNotice(name = "현장여사원 공지", category = NoticeCategory.COMPANY, scope = NoticeScope.FIELD_FEMALE_EMPLOYEE, createdDate = now.minus(1, java.time.temporal.ChronoUnit.HOURS))
+            persistNotice(name = "scope 미지정 공지", category = NoticeCategory.COMPANY, scope = null, createdDate = now.minus(2, java.time.temporal.ChronoUnit.HOURS))
+            persistNotice(name = "판매전략실 공지", category = NoticeCategory.COMPANY, scope = NoticeScope.SALES_EMPLOYEE, createdDate = now.minus(3, java.time.temporal.ChronoUnit.HOURS))
+
+            // When
+            val result = noticeRepository.findRecentNotices("부산1지점")
+
+            // Then
+            assertThat(result.map { it.name }).containsExactly("현장여사원 공지", "scope 미지정 공지")
         }
     }
 
@@ -324,6 +343,23 @@ class NoticeRepositoryTest {
             // Then
             assertThat(result.totalElements).isEqualTo(1)
             assertThat(result.content[0].name).isEqualTo("정상 공지")
+        }
+
+        @Test
+        @DisplayName("영업사원 공개범위 공지(예: 판매전략실)는 제외된다 - 레거시 scope 화이트리스트")
+        fun excludesSalesEmployeeScope() {
+            // Given
+            persistNotice(name = "현장여사원 공지", category = NoticeCategory.COMPANY, scope = NoticeScope.FIELD_FEMALE_EMPLOYEE)
+            persistNotice(name = "scope 미지정 공지", category = NoticeCategory.COMPANY, scope = null)
+            persistNotice(name = "판매전략실 공지", category = NoticeCategory.COMPANY, scope = NoticeScope.SALES_EMPLOYEE)
+
+            // When
+            val result = noticeRepository.findNotices(null, null, "서울지점", pageable)
+
+            // Then
+            assertThat(result.totalElements).isEqualTo(2)
+            assertThat(result.content.map { it.name })
+                .containsExactlyInAnyOrder("현장여사원 공지", "scope 미지정 공지")
         }
 
         @Test


### PR DESCRIPTION
레거시 communityMapper.xml#selectNotice 는 모든 공지 조회에
scope IN ('전체','현장여사원') 필터를 항상 적용해 scope='영업사원' 공지 (예: 【판매전략실】)를 홈/목록에서 제외했으나, 신규 findRecentNotices/
findNotices 는 category 만 필터하고 scope 를 누락해 노출되던 문제 수정.

SF DKRetail__Scope__c 피크리스트는 영업사원/현장여사원 2값만 존재('전체'는 레거시 UI 상수)하므로 "영업사원 제외"(scope IS NULL OR scope=현장여사원)로 변환. null/구'전체' 공지는 레거시 '전체' 의도대로 노출 유지.
관리자(findAllNotices)는 레거시에 없는 신규 관리 화면이라 전체 노출 유지.