### PR TITLE
style(order-form): 주문서 작성 화면 레거시 Heroku UI 정합

### DIFF
--- a/mobile/lib/presentation/pages/order_form_page.dart
+++ b/mobile/lib/presentation/pages/order_form_page.dart
@@ -232,25 +232,31 @@ class _OrderFormPageState extends ConsumerState<OrderFormPage> {
                       onQuantityChanged: notifier.updateProductQuantity,
                       scrollController: _scrollController,
                     ),
-                    const SizedBox(height: AppSpacing.lg),
-                    TotalAmountDisplay(
-                      totalAmount: state.totalAmount,
-                      creditBalance: state.creditBalance,
-                    ),
-                    const SizedBox(height: AppSpacing.lg),
-                    OrderFormActionButtons(
-                      onDelete: () => DraftDeleteDialog.show(
-                        context,
-                        onConfirm: () => notifier.deleteDraft(),
-                      ),
-                      onSaveDraft: () => notifier.saveDraft(),
-                      onSubmit: () => notifier.validateAndSubmitOrder(),
-                      isSubmitting: state.isSubmitting,
-                      hasItems: state.hasItems,
-                    ),
                     const SizedBox(height: AppSpacing.xxxl),
                   ],
                 ),
+              ),
+        // 레거시 write.jsp: 총 주문금액 + 삭제/임시저장/승인요청 하단 고정 바.
+        bottomNavigationBar: state.isLoading
+            ? null
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TotalAmountDisplay(
+                    totalAmount: state.totalAmount,
+                    creditBalance: state.creditBalance,
+                  ),
+                  OrderFormActionButtons(
+                    onDelete: () => DraftDeleteDialog.show(
+                      context,
+                      onConfirm: () => notifier.deleteDraft(),
+                    ),
+                    onSaveDraft: () => notifier.saveDraft(),
+                    onSubmit: () => notifier.validateAndSubmitOrder(),
+                    isSubmitting: state.isSubmitting,
+                    hasItems: state.hasItems,
+                  ),
+                ],
               ),
       ),
     );

--- a/mobile/lib/presentation/widgets/order_form/client_selector.dart
+++ b/mobile/lib/presentation/widgets/order_form/client_selector.dart
@@ -42,7 +42,7 @@ class ClientSelector extends StatelessWidget {
           // ignore: deprecated_member_use
           value: selectedClientId,
           hint: Text(
-            '선택하세요',
+            '거래처 선택',
             style: AppTypography.bodyMedium.copyWith(
               color: AppColors.textSecondary,
             ),

--- a/mobile/lib/presentation/widgets/order_form/credit_balance_display.dart
+++ b/mobile/lib/presentation/widgets/order_form/credit_balance_display.dart
@@ -23,33 +23,51 @@ class CreditBalanceDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!isLoading && creditBalance == null) {
-      return const SizedBox.shrink();
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          '여신 잔액',
-          style: AppTypography.bodySmall,
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        if (isLoading)
+    // 레거시(write.jsp #loanInquiry): 거래처 선택 전에도 항상 노출되며
+    // 미선택 시 "거래처를 선택하세요" 안내를 표시한다.
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.md,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
           Text(
-            '조회 중...',
-            style: AppTypography.headlineSmall.copyWith(
+            '여신 잔액',
+            style: AppTypography.bodySmall.copyWith(
               color: AppColors.textSecondary,
             ),
-          )
-        else if (creditBalance != null)
-          Text(
-            '${_formatNumber(creditBalance!)}원',
-            style: AppTypography.headlineSmall.copyWith(
-              color: AppColors.secondary,
-            ),
           ),
-      ],
+          const SizedBox(height: AppSpacing.xs),
+          if (isLoading)
+            Text(
+              '조회 중...',
+              style: AppTypography.headlineSmall.copyWith(
+                color: AppColors.textSecondary,
+              ),
+            )
+          else if (creditBalance != null)
+            Text(
+              '${_formatNumber(creditBalance!)}원',
+              style: AppTypography.headlineSmall.copyWith(
+                color: AppColors.secondary,
+              ),
+            )
+          else
+            Text(
+              '거래처를 선택하세요',
+              style: AppTypography.bodyMedium.copyWith(
+                color: AppColors.textTertiary,
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/presentation/widgets/order_form/delivery_date_picker.dart
+++ b/mobile/lib/presentation/widgets/order_form/delivery_date_picker.dart
@@ -57,16 +57,25 @@ class DeliveryDatePicker extends StatelessWidget {
               vertical: AppSpacing.md,
             ),
           ),
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              selectedDate != null ? _formatDate(selectedDate!) : '선택하세요',
-              style: AppTypography.bodyMedium.copyWith(
-                color: selectedDate != null
-                    ? AppColors.textPrimary
-                    : AppColors.textSecondary,
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  selectedDate != null ? _formatDate(selectedDate!) : '선택하세요',
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: selectedDate != null
+                        ? AppColors.textPrimary
+                        : AppColors.textSecondary,
+                  ),
+                ),
               ),
-            ),
+              // 레거시 HTML5 date input 의 캘린더 아이콘 외형 정합.
+              Icon(
+                Icons.calendar_today_outlined,
+                size: AppSpacing.iconSize,
+                color: AppColors.textSecondary,
+              ),
+            ],
           ),
         ),
       ],

--- a/mobile/lib/presentation/widgets/order_form/order_form_action_buttons.dart
+++ b/mobile/lib/presentation/widgets/order_form/order_form_action_buttons.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_colors.dart';
-import '../../../core/theme/app_spacing.dart';
+import '../../../core/theme/app_typography.dart';
 
 /// 주문서 작성 액션 버튼 (삭제/임시저장/승인요청)
 class OrderFormActionButtons extends StatelessWidget {
@@ -21,70 +21,101 @@ class OrderFormActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(
-          top: BorderSide(
-            color: AppColors.divider,
-            width: 1,
-          ),
+    // 레거시 write.jsp 하단 고정 바: 삭제(회색) / 임시저장(다크) / 승인요청(옐로) 풀폭 3분할.
+    final bool submitEnabled = !isSubmitting && hasItems;
+
+    return SafeArea(
+      top: false,
+      child: SizedBox(
+        height: 60,
+        child: Row(
+          children: [
+            _Segment(
+              flex: 2,
+              label: '삭제',
+              backgroundColor: AppColors.surfaceVariant,
+              foregroundColor: AppColors.textSecondary,
+              onPressed: isSubmitting ? null : onDelete,
+            ),
+            _Segment(
+              flex: 3,
+              label: '임시저장',
+              backgroundColor: AppColors.legacyTextSub,
+              foregroundColor: AppColors.white,
+              loading: isSubmitting,
+              onPressed: isSubmitting ? null : onSaveDraft,
+            ),
+            _Segment(
+              flex: 3,
+              label: '승인요청',
+              backgroundColor: AppColors.legacyYellow,
+              foregroundColor: AppColors.onPrimary,
+              disabledBackgroundColor: AppColors.surfaceVariant,
+              disabledForegroundColor: AppColors.textTertiary,
+              loading: isSubmitting,
+              onPressed: submitEnabled ? onSubmit : null,
+            ),
+          ],
         ),
       ),
-      padding: const EdgeInsets.all(AppSpacing.lg),
-      child: Row(
-        children: [
-          TextButton(
-            onPressed: isSubmitting ? null : onDelete,
-            style: TextButton.styleFrom(
-              foregroundColor: AppColors.error,
-            ),
-            child: const Text('삭제'),
-          ),
-          const Spacer(),
-          OutlinedButton(
-            onPressed: isSubmitting ? null : onSaveDraft,
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size(100, 48),
-              side: BorderSide(
-                color: isSubmitting ? AppColors.textSecondary : AppColors.border,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-              ),
-            ),
-            child: isSubmitting
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Text('임시저장'),
-          ),
-          const SizedBox(width: AppSpacing.sm),
-          ElevatedButton(
-            onPressed: (isSubmitting || !hasItems) ? null : onSubmit,
-            style: ElevatedButton.styleFrom(
-              minimumSize: const Size(100, 48),
-              backgroundColor: AppColors.primary,
-              foregroundColor: AppColors.onPrimary,
-              disabledBackgroundColor: AppColors.surface,
-              disabledForegroundColor: AppColors.textSecondary,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-              ),
-            ),
-            child: isSubmitting
-                ? const SizedBox(
+    );
+  }
+}
+
+/// 하단 고정 바의 단일 세그먼트 (풀-블리드, 모서리 없음).
+class _Segment extends StatelessWidget {
+  final int flex;
+  final String label;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final Color? disabledBackgroundColor;
+  final Color? disabledForegroundColor;
+  final bool loading;
+  final VoidCallback? onPressed;
+
+  const _Segment({
+    required this.flex,
+    required this.label,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    this.disabledBackgroundColor,
+    this.disabledForegroundColor,
+    this.loading = false,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bool enabled = onPressed != null;
+    final Color bg = enabled
+        ? backgroundColor
+        : (disabledBackgroundColor ?? backgroundColor);
+    final Color fg = enabled
+        ? foregroundColor
+        : (disabledForegroundColor ?? foregroundColor);
+
+    return Expanded(
+      flex: flex,
+      child: Material(
+        color: bg,
+        child: InkWell(
+          onTap: onPressed,
+          child: Center(
+            child: loading
+                ? SizedBox(
                     width: 20,
                     height: 20,
                     child: CircularProgressIndicator(
                       strokeWidth: 2,
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      valueColor: AlwaysStoppedAnimation<Color>(fg),
                     ),
                   )
-                : const Text('승인요청'),
+                : Text(
+                    label,
+                    style: AppTypography.headlineSmall.copyWith(color: fg),
+                  ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/mobile/lib/presentation/widgets/order_form/order_product_card.dart
+++ b/mobile/lib/presentation/widgets/order_form/order_product_card.dart
@@ -8,19 +8,20 @@ import '../../../domain/entities/validation_error.dart';
 
 /// 주문서 제품 카드
 class OrderProductCard extends StatelessWidget {
+  /// 라인 순번 (레거시 "N. (코드) 제품명" 표기용, 0-based).
+  final int index;
   final OrderDraftItem item;
   final ValidationError? validationError;
   final ValueChanged<bool?> onSelectionChanged;
   final Function(double boxes, int pieces) onQuantityChanged;
-  final VoidCallback onRemove;
 
   const OrderProductCard({
     super.key,
+    required this.index,
     required this.item,
     required this.validationError,
     required this.onSelectionChanged,
     required this.onQuantityChanged,
-    required this.onRemove,
   });
 
   String _formatNumber(int value) {
@@ -33,6 +34,9 @@ class OrderProductCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hasError = validationError != null;
+    // 레거시 write.jsp: 총 EA = 박스 × 1박스당 EA + 낱개.
+    final totalEach =
+        (item.quantityBoxes * item.boxSize).round() + item.quantityPieces;
 
     return Card(
       margin: const EdgeInsets.only(bottom: AppSpacing.md),
@@ -45,36 +49,36 @@ class OrderProductCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          CheckboxListTile(
-            value: item.isSelected,
-            onChanged: onSelectionChanged,
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.md,
-              vertical: AppSpacing.sm,
-            ),
-            title: Column(
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  item.productName,
-                  style: AppTypography.headlineSmall,
-                ),
-                const SizedBox(height: AppSpacing.xs),
-                Text(
-                  '제품코드: ${item.productCode}',
-                  style: AppTypography.bodySmall,
-                ),
-                const SizedBox(height: AppSpacing.sm),
+                // 레거시: "N. (제품코드) 제품명" + 우측 체크박스 (라인별 X 버튼 없음).
                 Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      '박스',
-                      style: AppTypography.bodyMedium,
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: AppSpacing.sm),
+                        child: Text(
+                          '${index + 1}. (${item.productCode}) ${item.productName}',
+                          style: AppTypography.headlineSmall,
+                        ),
+                      ),
                     ),
                     const SizedBox(width: AppSpacing.sm),
-                    SizedBox(
-                      width: 80,
+                    Checkbox(
+                      value: item.isSelected,
+                      onChanged: onSelectionChanged,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                // 레거시: [박스] [낱개(개)] 입력 + 총 EA 표시.
+                Row(
+                  children: [
+                    Expanded(
                       child: TextField(
                         controller: TextEditingController(
                           text: item.quantityBoxes > 0
@@ -91,6 +95,8 @@ class OrderProductCard extends StatelessWidget {
                         ],
                         decoration: InputDecoration(
                           isDense: true,
+                          hintText: '0',
+                          suffixText: '박스',
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: AppSpacing.sm,
                             vertical: AppSpacing.sm,
@@ -108,18 +114,7 @@ class OrderProductCard extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: AppSpacing.sm),
-                    Text(
-                      '개',
-                      style: AppTypography.bodyMedium,
-                    ),
-                    const SizedBox(width: AppSpacing.md),
-                    Text(
-                      '낱개',
-                      style: AppTypography.bodyMedium,
-                    ),
-                    const SizedBox(width: AppSpacing.sm),
-                    SizedBox(
-                      width: 80,
+                    Expanded(
                       child: TextField(
                         controller: TextEditingController(
                           text: item.quantityPieces > 0
@@ -132,6 +127,8 @@ class OrderProductCard extends StatelessWidget {
                         ],
                         decoration: InputDecoration(
                           isDense: true,
+                          hintText: '0',
+                          suffixText: '개',
                           contentPadding: const EdgeInsets.symmetric(
                             horizontal: AppSpacing.sm,
                             vertical: AppSpacing.sm,
@@ -148,29 +145,32 @@ class OrderProductCard extends StatelessWidget {
                         },
                       ),
                     ),
-                    const SizedBox(width: AppSpacing.sm),
+                    const SizedBox(width: AppSpacing.md),
                     Text(
-                      '개',
-                      style: AppTypography.bodyMedium,
+                      '총 ${_formatNumber(totalEach)}개',
+                      style: AppTypography.bodyMedium.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ],
                 ),
-                const SizedBox(height: AppSpacing.xs),
-                Text(
-                  '1박스 = ${item.boxSize}개',
-                  style: AppTypography.bodySmall,
-                ),
-                const SizedBox(height: AppSpacing.xs),
-                Text(
-                  '소계: ${_formatNumber(item.totalPrice)}원',
-                  style: AppTypography.labelLarge,
+                const SizedBox(height: AppSpacing.sm),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      '1박스 = ${item.boxSize}개',
+                      style: AppTypography.bodySmall.copyWith(
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                    Text(
+                      '소계: ${_formatNumber(item.totalPrice)}원',
+                      style: AppTypography.labelLarge,
+                    ),
+                  ],
                 ),
               ],
-            ),
-            secondary: IconButton(
-              icon: const Icon(Icons.close),
-              onPressed: onRemove,
-              color: AppColors.textSecondary,
             ),
           ),
           if (hasError)

--- a/mobile/lib/presentation/widgets/order_form/product_list_section.dart
+++ b/mobile/lib/presentation/widgets/order_form/product_list_section.dart
@@ -40,6 +40,7 @@ class ProductListSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // 레거시 write.jsp: "제품 *" 라벨 우측에 바코드 / +추가 버튼 배치.
         Row(
           children: [
             RichText(
@@ -55,27 +56,87 @@ class ProductListSection extends StatelessWidget {
                       color: AppColors.error,
                     ),
                   ),
-                  TextSpan(
-                    text: ' (수량: ${items.length}개)',
-                    style: AppTypography.bodySmall.copyWith(
-                      color: AppColors.textSecondary,
-                    ),
-                  ),
                 ],
               ),
             ),
             const Spacer(),
+            OutlinedButton.icon(
+              onPressed: onBarcodeScan,
+              icon: const Icon(Icons.qr_code_scanner, size: 18),
+              label: const Text('바코드'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.textPrimary,
+                side: BorderSide(color: AppColors.textSecondary),
+                shape: const StadiumBorder(),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.md,
+                ),
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            OutlinedButton.icon(
+              onPressed: onAddProduct,
+              icon: const Icon(Icons.add, size: 18),
+              label: const Text('추가'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.textPrimary,
+                side: BorderSide(color: AppColors.textSecondary),
+                shape: const StadiumBorder(),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.md,
+                ),
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
           ],
         ),
-        const SizedBox(height: AppSpacing.xs),
-        // Spec #598 P3-M §2.4 — 100개 안내 (회색, 단순 안내)
+        const SizedBox(height: AppSpacing.sm),
+        // 레거시 write.jsp: 100개 권장 안내 (빨강, 2줄).
         Text(
-          'ⓘ 제품은 100개 이하로 추가해주세요',
-          style: AppTypography.bodySmall.copyWith(
-            color: AppColors.textSecondary,
-          ),
+          '품목 추가는 100개 이하로 하시는 것을 권장합니다.',
+          style: AppTypography.bodySmall.copyWith(color: AppColors.error),
         ),
-        const SizedBox(height: AppSpacing.md),
+        Text(
+          '주문 품목이 100개를 초과하는 경우 분할하여 주문요청 부탁드립니다.',
+          style: AppTypography.bodySmall.copyWith(color: AppColors.error),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        // 레거시 write.jsp: 선택 삭제(좌, 빨강 버튼) / 전체 선택(우, 체크박스).
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: hasSelectedItems ? onRemoveSelected : null,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.error,
+                foregroundColor: AppColors.white,
+                // ignore: deprecated_member_use
+                disabledBackgroundColor: AppColors.error.withOpacity(0.4),
+                disabledForegroundColor: AppColors.white,
+                elevation: 0,
+                shape: const StadiumBorder(),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.lg,
+                ),
+                visualDensity: VisualDensity.compact,
+              ),
+              child: const Text('선택 삭제'),
+            ),
+            const Spacer(),
+            GestureDetector(
+              onTap: onToggleSelectAll,
+              child: Text(
+                '전체 선택',
+                style: AppTypography.bodyMedium,
+              ),
+            ),
+            Checkbox(
+              value: allItemsSelected,
+              onChanged: (value) => onToggleSelectAll(),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
         ListView.builder(
           controller: scrollController,
           shrinkWrap: true,
@@ -86,6 +147,7 @@ class ProductListSection extends StatelessWidget {
             final error = validationErrors[item.productCode];
 
             return OrderProductCard(
+              index: index,
               item: item,
               validationError: error,
               onSelectionChanged: (selected) {
@@ -94,76 +156,8 @@ class ProductListSection extends StatelessWidget {
               onQuantityChanged: (boxes, pieces) {
                 onQuantityChanged(item.productCode, boxes, pieces);
               },
-              onRemove: () {
-                onToggleSelection(item.productCode);
-                onRemoveSelected();
-              },
             );
           },
-        ),
-        const Divider(height: AppSpacing.lg),
-        Row(
-          children: [
-            Checkbox(
-              value: allItemsSelected,
-              onChanged: (value) => onToggleSelectAll(),
-            ),
-            GestureDetector(
-              onTap: onToggleSelectAll,
-              child: Text(
-                '전체 선택 / 해제',
-                style: AppTypography.bodyMedium,
-              ),
-            ),
-            const Spacer(),
-            TextButton(
-              onPressed: hasSelectedItems ? onRemoveSelected : null,
-              child: Text(
-                '선택 삭제',
-                style: AppTypography.labelMedium.copyWith(
-                  color: hasSelectedItems
-                      ? AppColors.error
-                      : AppColors.textSecondary,
-                ),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: AppSpacing.md),
-        Row(
-          children: [
-            Expanded(
-              child: OutlinedButton.icon(
-                onPressed: onBarcodeScan,
-                icon: const Icon(Icons.qr_code_scanner),
-                label: const Text('바코드'),
-                style: OutlinedButton.styleFrom(
-                  minimumSize: const Size(0, 48),
-                  side: BorderSide(color: AppColors.border),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: AppSpacing.md),
-            Expanded(
-              flex: 2,
-              child: ElevatedButton.icon(
-                onPressed: onAddProduct,
-                icon: const Icon(Icons.add),
-                label: const Text('추가'),
-                style: ElevatedButton.styleFrom(
-                  minimumSize: const Size(0, 48),
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: AppColors.onPrimary,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-                  ),
-                ),
-              ),
-            ),
-          ],
         ),
       ],
     );


### PR DESCRIPTION
레거시 write.jsp(#23) 기준으로 모바일 주문서 작성 화면 디자인 정합.

- 여신 잔액: 거래처 선택 전에도 항상 노출(회색 블록) + 미선택 안내
- 거래처: 드롭다운 유지, placeholder "거래처 선택"
- 납기일: 우측 캘린더 아이콘 추가
- 제품 헤더: 바코드/+추가 버튼을 라벨 우측 pill 로 이동
- 100개 안내: 회색 1줄 → 빨강 2줄
- 선택 삭제(빨강, 좌)/전체 선택(우) 위치·스타일 교체, 목록 위로 이동
- 제품 카드: "N. (코드) 제품명" + 우측 체크박스, 박스/개/총 개, 라인별 X 버튼 제거
- 하단 바: 풀폭 3분할 고정 footer(삭제/임시저장/승인요청) + 총 주문금액