### PR TITLE
fix(거래처): 부서장 전체조회 keyword/LIMIT 푸시다운 — broken pipe 해소

### DIFF
--- a/backend/src/main/kotlin/com/otoki/powersales/common/service/MyAccountService.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/common/service/MyAccountService.kt
@@ -45,8 +45,9 @@ class MyAccountService(
 
         val accounts = when {
             // C형(매출 계열) 부서장: 일정이 잡힌 전체 거래처 (레거시 selectAllAccount)
+            // 전사 거래처는 수천 건이라 keyword 필터 + 상한을 DB 레벨로 푸시다운 (레거시 검색+페이지네이션 정합).
             scope == MyAccountScope.SALES && employee.role == AppAuthority.ACCOUNT_VIEW_ALL ->
-                getAllScheduledAccounts()
+                getAllScheduledAccounts(keyword)
 
             // 조장 중 레거시 person-specific 예외(yang_sfid): 팀장 기준 스케줄 거래처 (레거시 selectMyAccount 조장 분기)
             employee.role == AppAuthority.LEADER && employee.sfid == LEGACY_SCHEDULE_LEADER_SFID ->
@@ -117,11 +118,13 @@ class MyAccountService(
     }
 
     /**
-     * 부서장(매출 계열) 거래처 조회: 일정이 잡힌 전체 거래처 (레거시 selectAllAccount — 본인/기간 필터 없음)
+     * 부서장(매출 계열) 거래처 조회: 일정이 잡힌 거래처 (레거시 selectAllAccount — 본인/기간 필터 없음).
+     * 전사 거래처가 수천 건이므로 keyword 필터 + 상한([ALL_ACCOUNTS_LIMIT])을 DB 레벨에서 적용한다.
      */
-    private fun getAllScheduledAccounts(): List<MyAccountInfo> {
-        val accountIds = teamMemberScheduleRepository.findAllDistinctAccountIds()
-        return toAccounts(accountIds)
+    private fun getAllScheduledAccounts(keyword: String?): List<MyAccountInfo> {
+        return teamMemberScheduleRepository
+            .findDistinctScheduledAccounts(keyword, ALL_ACCOUNTS_LIMIT)
+            .map { MyAccountInfo.from(it) }
     }
 
     private fun toAccounts(accountIds: List<Long>): List<MyAccountInfo> {
@@ -145,5 +148,8 @@ class MyAccountService(
         // 레거시 label.properties `yang_sfid` — 조장이지만 거래처 조회만 팀장 스케줄 기반(selectMyAccount)으로
         // 우회하는 person-specific 예외 1인. 레거시 PromotionController/ProductController 등 다수 화면 동일 처리.
         private const val LEGACY_SCHEDULE_LEADER_SFID = "a0c1y0000005452AAA"
+
+        // 부서장 전체조회 결과 상한 — 모바일 드롭다운 과대 응답(broken pipe) 방지. keyword 검색과 함께 사용.
+        private const val ALL_ACCOUNTS_LIMIT = 100
     }
 }

--- a/backend/src/main/kotlin/com/otoki/powersales/schedule/repository/TeamMemberScheduleRepositoryCustom.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/schedule/repository/TeamMemberScheduleRepositoryCustom.kt
@@ -84,11 +84,12 @@ interface TeamMemberScheduleRepositoryCustom {
     fun findDistinctAccountIdsByEmployeeIdAndDateRange(employeeId: Long, fromDate: LocalDate, toDate: LocalDate): List<Long>
 
     /**
-     * 팀멤버스케줄에 등록된 모든 거래처 ID (중복 제거).
-     * 레거시 `accountMapper.selectAllAccount` 정합 — 부서장(AppAuthority.ACCOUNT_VIEW_ALL) 매출 조회 시
-     * 본인/기간 필터 없이 일정이 잡힌 전체 거래처를 노출한다.
+     * 팀멤버스케줄에 등록된 거래처 (중복 제거) — 거래처명/코드 keyword 필터 + 결과 상한(limit).
+     * 레거시 `accountMapper.selectAllAccount` 정합 — 부서장(AppAuthority.ACCOUNT_VIEW_ALL) 매출 조회.
+     * 레거시 드롭다운이 `keyvalue` 검색 + `LIMIT/OFFSET` 페이지네이션을 쓰던 것과 동일하게,
+     * 전사 일정 거래처 전체(수천 건)를 한 번에 반환하지 않도록 DB 레벨에서 필터·제한한다.
      */
-    fun findAllDistinctAccountIds(): List<Long>
+    fun findDistinctScheduledAccounts(keyword: String?, limit: Int): List<com.otoki.powersales.account.entity.Account>
 
     /**
      * 팀장(teamLeader) 기준 거래처 ID (중복 제거).

--- a/backend/src/main/kotlin/com/otoki/powersales/schedule/repository/TeamMemberScheduleRepositoryCustomImpl.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/schedule/repository/TeamMemberScheduleRepositoryCustomImpl.kt
@@ -296,16 +296,28 @@ open class TeamMemberScheduleRepositoryCustomImpl(
             .filterNotNull()
     }
 
-    override fun findAllDistinctAccountIds(): List<Long> {
+    override fun findDistinctScheduledAccounts(
+        keyword: String?,
+        limit: Int
+    ): List<com.otoki.powersales.account.entity.Account> {
         return queryFactory
-            .select(teamMemberSchedule.account.id).distinct()
+            .select(account).distinct()
             .from(teamMemberSchedule)
+            .join(teamMemberSchedule.account, account)
             .where(
-                teamMemberSchedule.account.isNotNull,
-                isNotDeleted()
+                isNotDeleted(),
+                account.isDeleted.isNull.or(account.isDeleted.eq(false)),
+                accountKeywordMatch(keyword)
             )
+            .orderBy(account.name.asc())
+            .limit(limit.toLong())
             .fetch()
-            .filterNotNull()
+    }
+
+    private fun accountKeywordMatch(keyword: String?): BooleanExpression? {
+        if (keyword.isNullOrBlank()) return null
+        return account.name.containsIgnoreCase(keyword)
+            .or(account.externalKey.containsIgnoreCase(keyword))
     }
 
     override fun findDistinctAccountIdsByTeamLeaderIdAndDateRange(

--- a/backend/src/test/kotlin/com/otoki/powersales/common/service/MyAccountServiceTest.kt
+++ b/backend/src/test/kotlin/com/otoki/powersales/common/service/MyAccountServiceTest.kt
@@ -162,7 +162,7 @@ class MyAccountServiceTest {
     inner class AccountViewAllTests {
 
         @Test
-        @DisplayName("부서장 + scope=SALES -> 일정 잡힌 전체 거래처 조회")
+        @DisplayName("부서장 + scope=SALES -> 일정 잡힌 거래처 조회 (keyword/limit DB 푸시다운)")
         fun getMyAccounts_accountViewAll_salesScope_allAccounts() {
             val userId = 1L
             val employee = createEmployee(id = userId, employeeCode = "20030117", role = AppAuthority.ACCOUNT_VIEW_ALL)
@@ -172,13 +172,13 @@ class MyAccountServiceTest {
             )
 
             every { employeeRepository.findById(userId) } returns Optional.of(employee)
-            every { teamMemberScheduleRepository.findAllDistinctAccountIds() } returns listOf(1, 2)
-            every { accountRepository.findByIdInAndIsDeletedNot(listOf(1, 2), true) } returns accounts
+            every { teamMemberScheduleRepository.findDistinctScheduledAccounts(null, any()) } returns accounts
 
             val result = myAccountService.getMyAccounts(userId, null, MyAccountScope.SALES)
 
             assertThat(result.stores).hasSize(2)
-            verify { teamMemberScheduleRepository.findAllDistinctAccountIds() }
+            verify { teamMemberScheduleRepository.findDistinctScheduledAccounts(null, any()) }
+            verify(exactly = 0) { accountRepository.findByIdInAndIsDeletedNot(any(), any()) }
         }
 
         @Test
@@ -193,7 +193,7 @@ class MyAccountServiceTest {
             val result = myAccountService.getMyAccounts(userId, null, MyAccountScope.FIELD)
 
             assertThat(result.stores).isEmpty()
-            verify(exactly = 0) { teamMemberScheduleRepository.findAllDistinctAccountIds() }
+            verify(exactly = 0) { teamMemberScheduleRepository.findDistinctScheduledAccounts(any(), any()) }
             verify { teamMemberScheduleRepository.findDistinctAccountIdsByEmployeeIdAndDateRange(userId, any(), any()) }
         }
     }


### PR DESCRIPTION
부서장(AccountViewAll) 매출 조회 시 전사 일정 거래처 수천 건을 한 번에
반환해 모바일이 응답을 못 받고 끊던(Broken pipe) 문제 수정.

- selectAllAccount 정합(teammemberschedule 소스)은 유지하되, 거래처명/코드 keyword 필터 + 상한(LIMIT 100)을 DB 레벨로 푸시다운 (레거시 드롭다운의 keyvalue 검색 + LIMIT/OFFSET 페이지네이션과 동일 성격).
- findAllDistinctAccountIds(무제한 id → 거대 IN절) 제거 → findDistinctScheduledAccounts(keyword, limit): account ⋈ teammemberschedule 단일 JOIN 으로 거래처 직접 조회. 거대 IN절·과대 응답 둘 다 제거.