### PR TITLE
feat(월매출): 월 매출 현황 레거시 정합 — 목표/실적/진도율/기준진도율 데이터 연결

### DIFF
--- a/backend/openapi-mobile.json
+++ b/backend/openapi-mobile.json
@@ -4205,6 +4205,10 @@
             "format" : "double",
             "type" : "number"
           },
+          "baseRate" : {
+            "format" : "double",
+            "type" : "number"
+          },
           "categorySales" : {
             "items" : {
               "$ref" : "#/components/schemas/CategorySalesInfo"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -14856,6 +14856,10 @@
             "format" : "double",
             "type" : "number"
           },
+          "baseRate" : {
+            "format" : "double",
+            "type" : "number"
+          },
           "categorySales" : {
             "items" : {
               "$ref" : "#/components/schemas/CategorySalesInfo"

--- a/backend/src/main/kotlin/com/otoki/powersales/sales/dto/response/MonthlySalesResponse.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/sales/dto/response/MonthlySalesResponse.kt
@@ -10,6 +10,11 @@ data class MonthlySalesResponse(
     val targetAmount: Long,
     val achievedAmount: Long,
     val achievementRate: Double,
+    /**
+     * 기준 진도율 (영업일 기준, %) — 레거시 `calcBusinessRateOnlyThisMonth` 정합.
+     * 조회월이 시스템 당월일 때만 `(월초~오늘 영업일) / (월초~월말 영업일) × 100`, 그 외 월은 0.
+     */
+    val baseRate: Double,
     val categorySales: List<CategorySalesInfo>,
     val yearComparison: YearComparisonInfo,
     val monthlyAverage: MonthlyAverageInfo

--- a/backend/src/main/kotlin/com/otoki/powersales/sales/entity/WorkingDayMaster.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/sales/entity/WorkingDayMaster.kt
@@ -1,0 +1,64 @@
+package com.otoki.powersales.sales.entity
+
+import com.otoki.powersales.common.entity.BaseEntity
+import com.otoki.powersales.common.salesforce.SFField
+import com.otoki.powersales.common.salesforce.SFObject
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+/**
+ * 영업일관리마스터 Entity (SF `WorkingDayMaster__c`).
+ *
+ * 운영이 직접 관리하는 영업일 달력 — `workingDateCheck = 1` 인 날짜가 영업일이다 (주말/공휴일은 0).
+ * 월매출 현황 "기준 진도율"(레거시 SF `calcBusinessRateOnlyThisMonth`) 의 영업일수 산출 source.
+ *
+ * 데이터 권위: SF (HC sync 대상 아님 — Heroku PG 미존재. SF → RDS 단방향 마이그레이션 Stage1).
+ * Name 은 SF AutoNumber(`WM-{00000000}`) — 적재 정합 위해 보존하되 조회엔 미사용.
+ */
+@Entity
+@Table(name = "working_day_master")
+@SFObject("WorkingDayMaster__c")
+class WorkingDayMaster(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "working_day_master_id")
+    val id: Long = 0,
+
+    @Column(name = "sfid", length = 18, unique = true)
+    val sfid: String? = null,
+
+    @SFField("Name")
+    @Column(name = "name", length = 80)
+    val name: String? = null,
+
+    @SFField("WorkingDate__c")
+    @Column(name = "working_date")
+    var workingDate: LocalDate? = null,
+
+    /** SF `WorkingDateCheck__c` (Number, scale 0). 1 = 영업일. */
+    @SFField("WorkingDateCheck__c")
+    @Column(name = "working_date_check")
+    var workingDateCheck: Int? = null,
+
+    @SFField("IsDeleted")
+    @Column(name = "is_deleted")
+    val isDeleted: Boolean? = null,
+
+    @SFField("OwnerId")
+    @Column(name = "owner_sfid", length = 18)
+    var ownerSfid: String? = null,
+
+    @SFField("CreatedById")
+    @Column(name = "created_by_sfid", length = 18)
+    var createdBySfid: String? = null,
+
+    @SFField("LastModifiedById")
+    @Column(name = "last_modified_by_sfid", length = 18)
+    var lastModifiedBySfid: String? = null,
+) : BaseEntity()

--- a/backend/src/main/kotlin/com/otoki/powersales/sales/repository/SalesProgressRateMasterRepository.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/sales/repository/SalesProgressRateMasterRepository.kt
@@ -15,4 +15,12 @@ interface SalesProgressRateMasterRepository :
 
     /** ExternalKey(`연+월+거래처코드`) 일괄 조회 — SF fetch sync 의 upsert 매칭 키. */
     fun findByExternalKeyIn(externalKeys: Collection<String>): List<SalesProgressRateMaster>
+
+    /**
+     * 거래처(account FK) + 목표연도(`"YYYY"`) 목표 행 조회 — 월매출 현황 화면 목표 source.
+     *
+     * `targetMonth` 는 SF 적재 포맷(zero-pad 비보장) 이라 월 일치는 호출 측에서 정수 파싱으로 판정.
+     * soft-delete(`isDeleted == true`) 필터도 호출 측에서 수행 (`isDeleted` nullable).
+     */
+    fun findByAccountIdAndTargetYear(accountId: Long, targetYear: String): List<SalesProgressRateMaster>
 }

--- a/backend/src/main/kotlin/com/otoki/powersales/sales/repository/WorkingDayMasterRepository.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/sales/repository/WorkingDayMasterRepository.kt
@@ -1,0 +1,37 @@
+package com.otoki.powersales.sales.repository
+
+import com.otoki.powersales.sales.entity.WorkingDayMaster
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+
+/**
+ * 영업일관리마스터 Repository (SF `WorkingDayMaster__c`).
+ *
+ * 월매출 현황 "기준 진도율" 산출용 영업일수 count 를 제공한다.
+ */
+interface WorkingDayMasterRepository : JpaRepository<WorkingDayMaster, Long> {
+
+    /**
+     * `[start, end]` 구간의 영업일수 — `workingDateCheck = check` (영업일=1) row count.
+     *
+     * 레거시 SF SOQL `SELECT COUNT(Id) FROM WorkingDayMaster__c WHERE WorkingDate__c >= :start
+     * AND WorkingDate__c <= :end AND WorkingDateCheck__c = 1` 정합. SF SOQL 이 IsDeleted=true 를
+     * 자동 제외하는 것과 동등하게 soft-delete row(`isDeleted = true`)는 제외한다.
+     */
+    @Query(
+        """
+        SELECT COUNT(w) FROM WorkingDayMaster w
+        WHERE w.workingDate >= :start
+          AND w.workingDate <= :end
+          AND w.workingDateCheck = :check
+          AND (w.isDeleted IS NULL OR w.isDeleted = false)
+        """
+    )
+    fun countWorkingDays(
+        @Param("start") start: LocalDate,
+        @Param("end") end: LocalDate,
+        @Param("check") check: Int,
+    ): Long
+}

--- a/backend/src/main/kotlin/com/otoki/powersales/sales/service/MonthlySalesService.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/sales/service/MonthlySalesService.kt
@@ -1,40 +1,74 @@
 package com.otoki.powersales.sales.service
 
+import com.otoki.powersales.account.repository.AccountRepository
 import com.otoki.powersales.sales.dto.request.MonthlySalesRequest
 import com.otoki.powersales.sales.dto.response.MonthlySalesResponse
+import com.otoki.powersales.sales.entity.SalesProgressRateMaster
+import com.otoki.powersales.sales.repository.SalesProgressRateMasterRepository
+import com.otoki.powersales.sales.repository.WorkingDayMasterRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.time.LocalDate
 
 /**
  * 월매출 조회 service.
  *
- * ## 데이터 source
- * RDS `MonthlySalesHistory` (SF `MonthlySalesHistory__c` 복제 적재) 의 실측 마감실적만 사용
- * ([MonthlySalesHistoryQueryGateway] 경유). SF 레거시도 모바일 `IF_REST_MOBILE_MonthlySalesHistory.cls`
- * 가 ORORA 직접이 아닌 `MonthlySalesHistory__c` SObject 를 조회한 것과 동등.
- * 목표 (`thisMonthTarget`) / 확정 상태 (`isConfirmed`) 는 폐기 — 응답 필드 호환성 유지를 위해
- * `targetAmount = 0`, `achievementRate = 0.0` 로 고정 반환.
+ * ## 레거시 매핑
+ * - 진입점: 레거시 `POST /sales/monthlylistapi` → `promotion/month/list.jsp` (월 매출 현황)
+ * - flow-legacy: SF Apex `IF_REST_MOBILE_MonthlySalesHistory.cls` 1회 호출이 화면 데이터 전부
+ *   (Heroku PG mirror 조회 결과는 JSP 미참조) — 거래처(SAP 코드) 1곳 + 연월 기준
  *
- * ## 응답 산출
- * - `achievedAmount` = 카테고리 4종 ABC + Ship 합산 ([MonthlySalesRow.closingAmountSum] 동등)
- * - `categorySales` = 카테고리별 ABC + Ship 합산 — SF Apex `IF_REST_MOBILE_MonthlySalesHistory.cls` 정합
- * - `yearComparison` = 당년 / 전년 동월 ABC+Ship 합산
- * - `monthlyAverage` = 1월~조회월 누적 ABC+Ship 합산 / 월수 (당년 / 전년)
+ * ## 거래처 키 규약 (achieved=0 회귀 방지)
+ * 모바일/물류매출 화면과 동일하게 `customerId` 는 **신규 내부 `account.id`** 를 전달받는다
+ * ([LogisticsSalesService] 와 동일 규약). 숫자면 [AccountRepository] 로 resolve 하여 SAP 코드
+ * (`Account.externalKey`) 를 얻고, RDS 조회는 SAP 코드로 수행한다. 숫자가 아니면 레거시 SAP 코드
+ * 직접 호출(관리/테스트) 로 보고 그대로 사용한다.
+ *
+ * ## 데이터 source
+ * - 실적: RDS `MonthlySalesHistory` (SF `MonthlySalesHistory__c` 복제) 실측 마감실적
+ *   ([MonthlySalesHistoryQueryGateway] 경유).
+ * - 목표: RDS `SalesProgressRateMaster` (SF `SalesProgressRateMaster__c` 복제) — 조회 거래처의
+ *   해당 (연, 월) 1행. SF Apex SOQL `TargetYear__c = year AND TargetMonth__c = month AND
+ *   Account__r.ExternalKey__c = SAPAccountCode` 정합.
+ *
+ * ## 응답 산출 (레거시 list.jsp 정합)
+ * - `achievedAmount` = 조회월 `ClosingAmountSum` (ABC합 + Ship합) — "마감 합계 실적"
+ * - `targetAmount` = `RT + FR + RM + FO` 목표 합계 (SF `TargetSum__c` 동등) — "목표 금액"
+ * - `achievementRate` = `round(achieved / targetSum * 100)` — 진도율 바 + "(N% 달성)".
+ *   목표 미등록(targetSum=0) 월은 0 (레거시 `isNoTargetMonth` 분기 정합). 레거시 SF `ProgressRate__c`
+ *   (= `CurrentMonthSalesAmount__c / TargetSum__c`) 와 `CurrentMonthSalesAmount == ClosingAmountSum`
+ *   인 정상 케이스에서 동등하며, 화면 "(N% 달성)" 표기(실적÷목표) 와도 일치.
+ * - `categorySales` = 카테고리별 목표(RT/RM/FR/FO) + 실적(ABC+Ship) + 달성률(round(실적÷목표×100))
+ * - `baseRate` = 기준 진도율(영업일 경과 비율). 레거시 `calcBusinessRateOnlyThisMonth` 동등 — 상세는 [baseRate]
+ * - `yearComparison` = 당년 / 전년 동월 ClosingAmountSum
+ * - `monthlyAverage` = 1월~조회월 누적 ClosingAmountSum / 월수 (당년 / 전년)
  */
 @Service
 @Transactional(readOnly = true)
 class MonthlySalesService(
+    private val accountRepository: AccountRepository,
     private val monthlySalesHistoryGateway: MonthlySalesHistoryQueryGateway,
+    private val salesProgressRateMasterRepository: SalesProgressRateMasterRepository,
+    private val workingDayMasterRepository: WorkingDayMasterRepository,
 ) {
 
     fun getMonthlySales(request: MonthlySalesRequest): MonthlySalesResponse {
-        val customerId = request.customerId
+        val customerIdRaw = request.customerId
         val year = request.getYear()
         val month = request.getMonth()
-        val sapCode = customerId ?: ""
+        if (customerIdRaw.isNullOrBlank()) {
+            return emptyResponse("ALL", request.yearMonth, month)
+        }
+
+        // customerId(=내부 account.id) → SAP 코드 resolve. 숫자 아닌 값은 SAP 코드 직접 취급.
+        val account = customerIdRaw.toLongOrNull()
+            ?.let { accountRepository.findByIdInAndIsDeletedNot(listOf(it), true).firstOrNull() }
+            ?: accountRepository.findByExternalKey(customerIdRaw)
+        val sapCode = account?.externalKey ?: customerIdRaw
+        val customerName = account?.name ?: customerIdRaw
         if (sapCode.isBlank()) {
-            return emptyResponse(customerId ?: "ALL", request.yearMonth, year, month)
+            return emptyResponse(customerIdRaw, request.yearMonth, month)
         }
 
         val currentRangeSalesDates = (1..month).map { toSalesDate(year, it) }
@@ -54,14 +88,19 @@ class MonthlySalesService(
         val previousAvg = previousRangeSalesDates
             .sumOf { rowsByDate[it]?.closingAmountSum?.toLong() ?: 0L } / month
 
+        // 목표: 조회 거래처의 (연, 월) 1행. account 미resolve 시 목표 없음 (전체 0).
+        val target = account?.let { findTarget(it.id, year, month) }
+        val targetSum = target?.let { targetSumOf(it) } ?: 0L
+
         return MonthlySalesResponse(
-            customerId = customerId ?: sapCode,
-            customerName = customerId ?: sapCode,
+            customerId = customerIdRaw,
+            customerName = customerName,
             yearMonth = request.yearMonth,
-            targetAmount = 0L,
+            targetAmount = targetSum,
             achievedAmount = achieved,
-            achievementRate = 0.0,
-            categorySales = buildCategorySales(currentRow),
+            achievementRate = rate(achieved, targetSum),
+            baseRate = baseRate(year, month),
+            categorySales = buildCategorySales(currentRow, target),
             yearComparison = MonthlySalesResponse.YearComparisonInfo(achieved, previousAchieved),
             monthlyAverage = MonthlySalesResponse.MonthlyAverageInfo(
                 currentYearAverage = currentAvg,
@@ -72,7 +111,7 @@ class MonthlySalesService(
         )
     }
 
-    private fun emptyResponse(customerId: String, yearMonth: String, year: Int, month: Int) =
+    private fun emptyResponse(customerId: String, yearMonth: String, month: Int) =
         MonthlySalesResponse(
             customerId = customerId,
             customerName = customerId,
@@ -80,19 +119,36 @@ class MonthlySalesService(
             targetAmount = 0L,
             achievedAmount = 0L,
             achievementRate = 0.0,
+            baseRate = 0.0,
             categorySales = emptyList(),
             yearComparison = MonthlySalesResponse.YearComparisonInfo(0L, 0L),
             monthlyAverage = MonthlySalesResponse.MonthlyAverageInfo(0L, 0L, 1, month),
         )
 
-    private fun buildCategorySales(oro: MonthlySalesRow?): List<MonthlySalesResponse.CategorySalesInfo> {
-        if (oro == null) return emptyList()
+    /**
+     * 조회 거래처의 (연, 월) 목표 1행. `targetYear` 는 `"YYYY"` 문자열, `targetMonth` 는 SF 적재
+     * 포맷(zero-pad 비보장) 이라 정수 파싱 후 월 일치로 매칭. soft-delete row 제외.
+     */
+    private fun findTarget(accountId: Long, year: Int, month: Int): SalesProgressRateMaster? =
+        salesProgressRateMasterRepository
+            .findByAccountIdAndTargetYear(accountId, year.toString())
+            .asSequence()
+            .filter { it.isDeleted != true }
+            .firstOrNull { it.targetMonth?.trim()?.toIntOrNull() == month }
+
+    private fun buildCategorySales(
+        oro: MonthlySalesRow?,
+        target: SalesProgressRateMaster?,
+    ): List<MonthlySalesResponse.CategorySalesInfo> {
+        if (oro == null && target == null) return emptyList()
         return SalesCategory.entries.map { category ->
+            val achievedAmount = oro?.let { categoryAchieved(it, category) } ?: 0L
+            val targetAmount = target?.let { categoryTarget(it, category) } ?: 0L
             MonthlySalesResponse.CategorySalesInfo(
                 category = category.name,
-                targetAmount = 0L,
-                achievedAmount = categoryAchieved(oro, category),
-                achievementRate = 0.0,
+                targetAmount = targetAmount,
+                achievedAmount = achievedAmount,
+                achievementRate = rate(achievedAmount, targetAmount),
             )
         }
     }
@@ -113,5 +169,55 @@ class MonthlySalesService(
         return (abc ?: BigDecimal.ZERO).toLong() + (ship ?: BigDecimal.ZERO).toLong()
     }
 
+    /** 카테고리별 목표 — SF `RT/RM/FR/FO TargetAmount__c` 정합. */
+    private fun categoryTarget(target: SalesProgressRateMaster, category: SalesCategory): Long {
+        val amount = when (category) {
+            SalesCategory.AMBIENT -> target.rtTargetAmount
+            SalesCategory.NOODLE -> target.rmTargetAmount
+            SalesCategory.FROZEN_REFRIGERATED -> target.frTargetAmount
+            SalesCategory.OIL_FAT -> target.foTargetAmount
+        }
+        return amount?.toLong() ?: 0L
+    }
+
+    /** 목표 합계 — SF `TargetSum__c` (= RT + FR + RM + FO) 동등. */
+    private fun targetSumOf(target: SalesProgressRateMaster): Long =
+        ((target.rtTargetAmount ?: 0.0) +
+            (target.frTargetAmount ?: 0.0) +
+            (target.rmTargetAmount ?: 0.0) +
+            (target.foTargetAmount ?: 0.0)).toLong()
+
+    /** 달성률 — `round(실적 / 목표 × 100)`. 목표 0 이면 0 (NaN/Infinity 방지, 레거시 정합). */
+    private fun rate(achieved: Long, target: Long): Double =
+        if (target <= 0L) 0.0 else Math.round(achieved.toDouble() / target * 100).toDouble()
+
+    /**
+     * 기준 진도율 (영업일 기준, %) — 레거시 SF `calcBusinessRateOnlyThisMonth` **byte 단위 정합**.
+     *
+     * 조회월이 시스템 당월일 때만 `(월초~오늘 영업일) / (월초~월말 영업일) × 100`, 그 외(과거/미래)
+     * 월은 0 (레거시 JSP 동일 — `MonthlySalesAdminQueryService.referenceAchievementRate` 의 admin
+     * 정책(과거 100) 과 다름).
+     *
+     * **영업일 source = `WorkingDayMaster`** (SF `WorkingDayMaster__c` 복제) 의 `workingDateCheck = 1`
+     * row 를 기간 count — 레거시 SF SOQL 과 동일 소스/조건. 평일·공휴일을 코드로 유추하지 않고 운영
+     * 영업일 달력 그대로 사용하므로 토요일 영업일 지정 등 운영 규칙까지 정확히 반영된다.
+     * 마스터 미적재(빈 테이블) 시 `total <= 0` → 0 반환 (graceful, 레거시 `fromEndDayCnt <= 0` 정합).
+     */
+    private fun baseRate(year: Int, month: Int): Double {
+        val today = LocalDate.now()
+        if (today.year != year || today.monthValue != month) return 0.0
+        val firstDay = LocalDate.of(year, month, 1)
+        val lastDay = firstDay.withDayOfMonth(firstDay.lengthOfMonth())
+        val totalWorkingDays = workingDayMasterRepository.countWorkingDays(firstDay, lastDay, WORKING_DAY_CHECK)
+        if (totalWorkingDays <= 0L) return 0.0
+        val elapsedWorkingDays = workingDayMasterRepository.countWorkingDays(firstDay, today, WORKING_DAY_CHECK)
+        return elapsedWorkingDays.toDouble() / totalWorkingDays.toDouble() * 100.0
+    }
+
     private fun toSalesDate(year: Int, month: Int): String = "%04d%02d".format(year, month)
+
+    private companion object {
+        /** SF `WorkingDateCheck__c` 의 영업일 값. */
+        const val WORKING_DAY_CHECK = 1
+    }
 }

--- a/backend/src/main/kotlin/com/otoki/powersales/sfmigration/stage1/Stage1Targets.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/sfmigration/stage1/Stage1Targets.kt
@@ -709,6 +709,25 @@ object Stage1Targets {
         ),
     )
 
+    private val WORKING_DAY_MASTER = EntityMetadata(
+        targetName = "WorkingDayMaster",
+        sObjectName = "WorkingDayMaster__c",
+        tableName = "working_day_master",
+        csvFileName = "working_day_masters.csv",
+        fields = listOf(
+            FieldMapping("Id", "sfid", nullable = false),
+            FieldMapping("Name", "name"),
+            FieldMapping("WorkingDate__c", "working_date"),
+            FieldMapping("WorkingDateCheck__c", "working_date_check"),
+            FieldMapping("OwnerId", "owner_sfid"),
+            FieldMapping("CreatedById", "created_by_sfid"),
+            FieldMapping("CreatedDate", "created_at", nullable = false),
+            FieldMapping("LastModifiedDate", "updated_at", nullable = false),
+            FieldMapping("LastModifiedById", "last_modified_by_sfid"),
+            FieldMapping("IsDeleted", "is_deleted"),
+        ),
+    )
+
     private val INSPECTION_THEME = EntityMetadata(
         targetName = "InspectionTheme",
         sObjectName = "Theme__c",
@@ -1715,6 +1734,7 @@ object Stage1Targets {
         ERP_ORDER,
         ERP_ORDER_PRODUCT,
         HOLIDAY_MASTER,
+        WORKING_DAY_MASTER,
         INSPECTION_THEME,
         SITE_ACTIVITY,
         MONTHLY_FEMALE_EMPLOYEE_INTEGRATION_SCHEDULE,
@@ -1795,6 +1815,7 @@ object Stage1Targets {
         "ErpOrder",
         "ErpOrderProduct",
         "HolidayMaster",
+        "WorkingDayMaster",
         "InspectionTheme",
         "SiteActivity",
         "MonthlyFemaleEmployeeIntegrationSchedule",

--- a/backend/src/main/resources/db/migration/V202606101000__create_working_day_master.sql
+++ b/backend/src/main/resources/db/migration/V202606101000__create_working_day_master.sql
@@ -1,0 +1,31 @@
+-- 영업일관리마스터 (SF WorkingDayMaster__c) 테이블 신규 생성.
+--
+-- 목적: 월매출 현황 "기준 진도율"(레거시 SF `calcBusinessRateOnlyThisMonth`) 의 영업일수 산출 source.
+--   레거시는 `WorkingDayMaster__c` 에서 `WorkingDateCheck__c = 1` (영업일) row 를 기간 count 한다.
+--   평일/공휴일 규칙을 코드로 유추하지 않고 운영이 직접 관리하는 영업일 달력 그대로 복제해야
+--   레거시와 영업일수가 일치하므로, 동 마스터를 SF → RDS 단방향 마이그레이션(Stage1) 으로 적재한다.
+--
+-- 데이터 권위: SF (HC sync 대상 아님 — Heroku PG 미존재. SF → RDS 단방향 마이그레이션).
+-- 스키마 권위: entity `WorkingDayMaster` (@Column).
+-- 표준 필드: Id / Name(AutoNumber) / WorkingDate__c(Date) / WorkingDateCheck__c(Number) + audit + IsDeleted.
+
+CREATE TABLE powersales.working_day_master (
+    working_day_master_id    BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    sfid                     VARCHAR(18),
+    name                     VARCHAR(80),
+    working_date             DATE,
+    -- SF WorkingDateCheck__c (Number, scale 0) — 1 = 영업일.
+    working_date_check       INTEGER,
+    is_deleted               BOOLEAN,
+    owner_sfid               VARCHAR(18),
+    created_by_sfid          VARCHAR(18),
+    last_modified_by_sfid    VARCHAR(18),
+    -- BaseEntity
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT uk_working_day_master_sfid UNIQUE (sfid)
+);
+
+-- 기준 진도율 산출은 (working_date BETWEEN ... AND working_date_check = 1) 범위 count 가 hot path.
+CREATE INDEX idx_working_day_master_date_check
+    ON powersales.working_day_master (working_date, working_date_check);

--- a/backend/src/test/kotlin/com/otoki/powersales/sales/controller/MonthlySalesControllerTest.kt
+++ b/backend/src/test/kotlin/com/otoki/powersales/sales/controller/MonthlySalesControllerTest.kt
@@ -54,6 +54,7 @@ class MonthlySalesControllerTest : MobileControllerTestSupport() {
             targetAmount = 28900000,
             achievedAmount = 30089000,
             achievementRate = 104.11,
+            baseRate = 50.0,
             categorySales = listOf(
                 MonthlySalesResponse.CategorySalesInfo(
                     category = "상온",
@@ -96,6 +97,7 @@ class MonthlySalesControllerTest : MobileControllerTestSupport() {
             .andExpect(jsonPath("$.data.yearMonth").value("202602"))
             .andExpect(jsonPath("$.data.targetAmount").value(28900000))
             .andExpect(jsonPath("$.data.achievedAmount").value(30089000))
+            .andExpect(jsonPath("$.data.baseRate").value(50.0))
             .andExpect(jsonPath("$.data.categorySales[0].category").value("상온"))
             .andExpect(jsonPath("$.data.yearComparison.currentYear").value(30089000))
             .andExpect(jsonPath("$.data.monthlyAverage.currentYearAverage").value(28500000))
@@ -245,6 +247,7 @@ class MonthlySalesControllerTest : MobileControllerTestSupport() {
             targetAmount = 100000000,
             achievedAmount = 120000000,
             achievementRate = 120.0,
+            baseRate = 0.0,
             categorySales = emptyList(),
             yearComparison = MonthlySalesResponse.YearComparisonInfo(0, 0),
             monthlyAverage = MonthlySalesResponse.MonthlyAverageInfo(0, 0, 1, 2)

--- a/backend/src/test/kotlin/com/otoki/powersales/sales/service/MonthlySalesServiceTest.kt
+++ b/backend/src/test/kotlin/com/otoki/powersales/sales/service/MonthlySalesServiceTest.kt
@@ -1,18 +1,33 @@
 package com.otoki.powersales.sales.service
 
+import com.otoki.powersales.account.entity.Account
+import com.otoki.powersales.account.repository.AccountRepository
 import com.otoki.powersales.sales.dto.request.MonthlySalesRequest
+import com.otoki.powersales.sales.entity.SalesProgressRateMaster
+import com.otoki.powersales.sales.repository.SalesProgressRateMasterRepository
+import com.otoki.powersales.sales.repository.WorkingDayMasterRepository
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
 
 @DisplayName("MonthlySalesService 테스트")
 class MonthlySalesServiceTest {
 
+    private val accountRepository: AccountRepository = mockk()
     private val monthlySalesHistoryGateway: MonthlySalesHistoryQueryGateway = mockk()
-    private val service = MonthlySalesService(monthlySalesHistoryGateway)
+    private val salesProgressRateMasterRepository: SalesProgressRateMasterRepository = mockk()
+    private val workingDayMasterRepository: WorkingDayMasterRepository = mockk()
+    private val service = MonthlySalesService(
+        accountRepository,
+        monthlySalesHistoryGateway,
+        salesProgressRateMasterRepository,
+        workingDayMasterRepository,
+    )
 
     @Nested
     @DisplayName("getMonthlySales — RDS 기반 응답")
@@ -21,6 +36,8 @@ class MonthlySalesServiceTest {
         @Test
         @DisplayName("customerId / yearMonth 가 응답에 그대로 전달된다")
         fun returnsRequestEcho() {
+            // "C001" 은 숫자가 아니라 SAP 코드 직접 호출 경로 — account 미매칭(목표 없음).
+            every { accountRepository.findByExternalKey("C001") } returns null
             every { monthlySalesHistoryGateway.findBySalesDates(any(), any()) } returns emptyList()
 
             val result = service.getMonthlySales(
@@ -42,6 +59,118 @@ class MonthlySalesServiceTest {
 
             assertThat(result.customerId).isEqualTo("ALL")
             assertThat(result.achievedAmount).isEqualTo(0L)
+        }
+
+        @Test
+        @DisplayName("숫자 customerId(=account.id) → SAP 코드 resolve 후 실적/목표/달성률 산출")
+        fun numericCustomerIdResolvesAccountAndTarget() {
+            // account.id=100 → SAP 코드 1000091 resolve (물류매출 service 와 동일 규약).
+            val account = mockk<Account> {
+                every { id } returns 100L
+                every { externalKey } returns "1000091"
+                every { name } returns "(주)이마트 월배점"
+            }
+            every {
+                accountRepository.findByIdInAndIsDeletedNot(listOf(100L), true)
+            } returns listOf(account)
+
+            // 조회월(202605) 마감 합계 실적 7,796만원. 카테고리 개별 컬럼은 비고 합계만 적재된 케이스.
+            every { monthlySalesHistoryGateway.findBySalesDates(any(), listOf("1000091")) } returns listOf(
+                MonthlySalesRow(
+                    sapAccountCode = "1000091",
+                    salesDate = "202605",
+                    closingAmountSum = BigDecimal("77960000"),
+                    abcClosingAmount1 = null,
+                )
+            )
+
+            // 목표: 상온 4,597만 / 라면 2,040만 / 냉동냉장 2,519만 / 유지 41만 → 합계 9,197만.
+            val target = mockk<SalesProgressRateMaster> {
+                every { isDeleted } returns null
+                every { targetMonth } returns "5"
+                every { rtTargetAmount } returns 45_970_000.0
+                every { rmTargetAmount } returns 20_400_000.0
+                every { frTargetAmount } returns 25_190_000.0
+                every { foTargetAmount } returns 410_000.0
+            }
+            every {
+                salesProgressRateMasterRepository.findByAccountIdAndTargetYear(100L, "2026")
+            } returns listOf(target)
+
+            val result = service.getMonthlySales(
+                MonthlySalesRequest(customerId = "100", yearMonth = "202605")
+            )
+
+            assertThat(result.customerName).isEqualTo("(주)이마트 월배점")
+            assertThat(result.achievedAmount).isEqualTo(77_960_000L)
+            assertThat(result.targetAmount).isEqualTo(91_970_000L)
+            // round(7796 / 9197 * 100) = 85
+            assertThat(result.achievementRate).isEqualTo(85.0)
+            assertThat(result.categorySales).hasSize(4)
+            val ambient = result.categorySales.first { it.category == "AMBIENT" }
+            assertThat(ambient.targetAmount).isEqualTo(45_970_000L)
+        }
+
+        @Test
+        @DisplayName("과거 월 조회 시 기준 진도율(baseRate) 은 0 (레거시 calcBusinessRateOnlyThisMonth 정합)")
+        fun baseRateZeroForPastMonth() {
+            every { accountRepository.findByExternalKey("C001") } returns null
+            every { monthlySalesHistoryGateway.findBySalesDates(any(), any()) } returns emptyList()
+
+            // 2000년 1월은 시스템 당월이 아니므로 baseRate=0.
+            val result = service.getMonthlySales(
+                MonthlySalesRequest(customerId = "C001", yearMonth = "200001")
+            )
+
+            assertThat(result.baseRate).isEqualTo(0.0)
+        }
+    }
+
+    @Nested
+    @DisplayName("baseRate — WorkingDayMaster 기반 기준 진도율 (레거시 calcBusinessRateOnlyThisMonth)")
+    inner class BaseRateTests {
+
+        @Test
+        @DisplayName("당월 조회 시 WorkingDayMaster 영업일 count 로 (경과/전체)×100 산출")
+        fun currentMonthUsesWorkingDayMaster() {
+            val now = LocalDate.now()
+            val yearMonth = "%04d%02d".format(now.year, now.monthValue)
+            val firstDay = LocalDate.of(now.year, now.monthValue, 1)
+            val lastDay = firstDay.withDayOfMonth(firstDay.lengthOfMonth())
+
+            every { accountRepository.findByExternalKey("C001") } returns null
+            every { monthlySalesHistoryGateway.findBySalesDates(any(), any()) } returns emptyList()
+            // 전체 영업일 20, 월초~오늘 경과 영업일 10 → 50%.
+            every { workingDayMasterRepository.countWorkingDays(firstDay, lastDay, 1) } returns 20L
+            if (now != lastDay) {
+                every { workingDayMasterRepository.countWorkingDays(firstDay, now, 1) } returns 10L
+            }
+            val expected = if (now == lastDay) 100.0 else 50.0
+
+            val result = service.getMonthlySales(
+                MonthlySalesRequest(customerId = "C001", yearMonth = yearMonth)
+            )
+
+            assertThat(result.baseRate).isEqualTo(expected)
+        }
+
+        @Test
+        @DisplayName("당월이라도 WorkingDayMaster 미적재(전체 영업일 0)면 0")
+        fun currentMonthEmptyMasterReturnsZero() {
+            val now = LocalDate.now()
+            val yearMonth = "%04d%02d".format(now.year, now.monthValue)
+            val firstDay = LocalDate.of(now.year, now.monthValue, 1)
+            val lastDay = firstDay.withDayOfMonth(firstDay.lengthOfMonth())
+
+            every { accountRepository.findByExternalKey("C001") } returns null
+            every { monthlySalesHistoryGateway.findBySalesDates(any(), any()) } returns emptyList()
+            every { workingDayMasterRepository.countWorkingDays(firstDay, lastDay, 1) } returns 0L
+
+            val result = service.getMonthlySales(
+                MonthlySalesRequest(customerId = "C001", yearMonth = yearMonth)
+            )
+
+            assertThat(result.baseRate).isEqualTo(0.0)
         }
     }
 }

--- a/mobile/lib/data/mock/monthly_sales_mock_data.dart
+++ b/mobile/lib/data/mock/monthly_sales_mock_data.dart
@@ -12,6 +12,7 @@ class MonthlySalesMockData {
       targetAmount: 100000000,
       achievedAmount: 95000000,
       achievementRate: 95.0,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -41,6 +42,7 @@ class MonthlySalesMockData {
       targetAmount: 80000000,
       achievedAmount: 65000000,
       achievementRate: 81.25,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -72,6 +74,7 @@ class MonthlySalesMockData {
       targetAmount: 70000000,
       achievedAmount: 72000000,
       achievementRate: 102.9,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -101,6 +104,7 @@ class MonthlySalesMockData {
       targetAmount: 60000000,
       achievedAmount: 50000000,
       achievementRate: 83.3,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -132,6 +136,7 @@ class MonthlySalesMockData {
       targetAmount: 50000000,
       achievedAmount: 48000000,
       achievementRate: 96.0,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -161,6 +166,7 @@ class MonthlySalesMockData {
       targetAmount: 55000000,
       achievedAmount: 40000000,
       achievementRate: 72.7,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -192,6 +198,7 @@ class MonthlySalesMockData {
       targetAmount: 220000000,
       achievedAmount: 215000000,
       achievementRate: 97.7,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',
@@ -221,6 +228,7 @@ class MonthlySalesMockData {
       targetAmount: 195000000,
       achievedAmount: 155000000,
       achievementRate: 79.5,
+      baseRate: 0.0,
       categorySales: const [
         CategorySales(
           category: '상온',

--- a/mobile/lib/data/models/monthly_sales_model.dart
+++ b/mobile/lib/data/models/monthly_sales_model.dart
@@ -165,6 +165,7 @@ class MonthlySalesModel {
   final int targetAmount;
   final int achievedAmount;
   final double achievementRate;
+  final double baseRate;
   final List<CategorySalesModel> categorySales;
   final int previousYearSameMonth;
   final MonthlyAverageModel monthlyAverage;
@@ -176,6 +177,7 @@ class MonthlySalesModel {
     required this.targetAmount,
     required this.achievedAmount,
     required this.achievementRate,
+    required this.baseRate,
     required this.categorySales,
     required this.previousYearSameMonth,
     required this.monthlyAverage,
@@ -193,6 +195,7 @@ class MonthlySalesModel {
       targetAmount: (json['targetAmount'] as num).toInt(),
       achievedAmount: (json['achievedAmount'] as num).toInt(),
       achievementRate: (json['achievementRate'] as num).toDouble(),
+      baseRate: (json['baseRate'] as num?)?.toDouble() ?? 0.0,
       categorySales: (json['categorySales'] as List<dynamic>)
           .map((item) => CategorySalesModel.fromJson(item as Map<String, dynamic>))
           .toList(),
@@ -211,6 +214,7 @@ class MonthlySalesModel {
       'targetAmount': targetAmount,
       'achievedAmount': achievedAmount,
       'achievementRate': achievementRate,
+      'baseRate': baseRate,
       'categorySales': categorySales.map((item) => item.toJson()).toList(),
       'previousYearSameMonth': previousYearSameMonth,
       'monthlyAverage': monthlyAverage.toJson(),
@@ -225,6 +229,7 @@ class MonthlySalesModel {
       targetAmount: targetAmount,
       achievedAmount: achievedAmount,
       achievementRate: achievementRate,
+      baseRate: baseRate,
       categorySales: categorySales.map((model) => model.toEntity()).toList(),
       previousYearSameMonth: previousYearSameMonth,
       monthlyAverage: monthlyAverage.toEntity(),
@@ -239,6 +244,7 @@ class MonthlySalesModel {
       targetAmount: entity.targetAmount,
       achievedAmount: entity.achievedAmount,
       achievementRate: entity.achievementRate,
+      baseRate: entity.baseRate,
       categorySales: entity.categorySales
           .map((item) => CategorySalesModel.fromEntity(item))
           .toList(),
@@ -257,6 +263,7 @@ class MonthlySalesModel {
         other.targetAmount == targetAmount &&
         other.achievedAmount == achievedAmount &&
         other.achievementRate == achievementRate &&
+        other.baseRate == baseRate &&
         _listEquals(other.categorySales, categorySales) &&
         other.previousYearSameMonth == previousYearSameMonth &&
         other.monthlyAverage == monthlyAverage;
@@ -271,6 +278,7 @@ class MonthlySalesModel {
       targetAmount,
       achievedAmount,
       achievementRate,
+      baseRate,
       Object.hashAll(categorySales),
       previousYearSameMonth,
       monthlyAverage,
@@ -282,7 +290,7 @@ class MonthlySalesModel {
     return 'MonthlySalesModel(customerId: $customerId, '
         'customerName: $customerName, yearMonth: $yearMonth, '
         'targetAmount: $targetAmount, achievedAmount: $achievedAmount, '
-        'achievementRate: $achievementRate%, '
+        'achievementRate: $achievementRate%, baseRate: $baseRate%, '
         'categorySales: ${categorySales.length} items, '
         'previousYearSameMonth: $previousYearSameMonth, '
         'monthlyAverage: $monthlyAverage)';

--- a/mobile/lib/domain/entities/monthly_sales.dart
+++ b/mobile/lib/domain/entities/monthly_sales.dart
@@ -185,6 +185,12 @@ class MonthlySales {
   /// 달성율 (%)
   final double achievementRate;
 
+  /// 기준 진도율 (영업일 기준, %)
+  ///
+  /// 조회월이 당월일 때만 `(월초~오늘 영업일) / (월초~월말 영업일) × 100`,
+  /// 그 외(과거/미래) 월은 0 (레거시 calcBusinessRateOnlyThisMonth 정합).
+  final double baseRate;
+
   /// 제품유형별 매출
   final List<CategorySales> categorySales;
 
@@ -201,6 +207,7 @@ class MonthlySales {
     required this.targetAmount,
     required this.achievedAmount,
     required this.achievementRate,
+    required this.baseRate,
     required this.categorySales,
     required this.previousYearSameMonth,
     required this.monthlyAverage,
@@ -213,6 +220,7 @@ class MonthlySales {
     int? targetAmount,
     int? achievedAmount,
     double? achievementRate,
+    double? baseRate,
     List<CategorySales>? categorySales,
     int? previousYearSameMonth,
     MonthlyAverage? monthlyAverage,
@@ -224,6 +232,7 @@ class MonthlySales {
       targetAmount: targetAmount ?? this.targetAmount,
       achievedAmount: achievedAmount ?? this.achievedAmount,
       achievementRate: achievementRate ?? this.achievementRate,
+      baseRate: baseRate ?? this.baseRate,
       categorySales: categorySales ?? this.categorySales,
       previousYearSameMonth:
           previousYearSameMonth ?? this.previousYearSameMonth,
@@ -239,6 +248,7 @@ class MonthlySales {
       'targetAmount': targetAmount,
       'achievedAmount': achievedAmount,
       'achievementRate': achievementRate,
+      'baseRate': baseRate,
       'categorySales': categorySales.map((c) => c.toJson()).toList(),
       'previousYearSameMonth': previousYearSameMonth,
       'monthlyAverage': monthlyAverage.toJson(),
@@ -253,6 +263,7 @@ class MonthlySales {
       targetAmount: json['targetAmount'] as int,
       achievedAmount: json['achievedAmount'] as int,
       achievementRate: (json['achievementRate'] as num).toDouble(),
+      baseRate: (json['baseRate'] as num?)?.toDouble() ?? 0.0,
       categorySales: (json['categorySales'] as List)
           .map((item) => CategorySales.fromJson(item as Map<String, dynamic>))
           .toList(),
@@ -272,6 +283,7 @@ class MonthlySales {
         other.targetAmount == targetAmount &&
         other.achievedAmount == achievedAmount &&
         other.achievementRate == achievementRate &&
+        other.baseRate == baseRate &&
         _listEquals(other.categorySales, categorySales) &&
         other.previousYearSameMonth == previousYearSameMonth &&
         other.monthlyAverage == monthlyAverage;
@@ -286,6 +298,7 @@ class MonthlySales {
       targetAmount,
       achievedAmount,
       achievementRate,
+      baseRate,
       Object.hashAll(categorySales),
       previousYearSameMonth,
       monthlyAverage,
@@ -297,6 +310,7 @@ class MonthlySales {
     return 'MonthlySales(customerId: $customerId, customerName: $customerName, '
         'yearMonth: $yearMonth, targetAmount: $targetAmount, '
         'achievedAmount: $achievedAmount, achievementRate: $achievementRate, '
+        'baseRate: $baseRate, '
         'categorySales: $categorySales, '
         'previousYearSameMonth: $previousYearSameMonth, '
         'monthlyAverage: $monthlyAverage)';

--- a/mobile/lib/presentation/pages/monthly_sales_tab_page.dart
+++ b/mobile/lib/presentation/pages/monthly_sales_tab_page.dart
@@ -174,7 +174,7 @@ class _MonthlySalesTabPageState extends ConsumerState<MonthlySalesTabPage> {
                         backgroundColor: AppColors.surface,
                         // 진도율 >= 기준 진도율이면 상승(녹색), 미달이면 하락(적색) — 레거시 is-up/is-down 정합
                         valueColor: AlwaysStoppedAnimation<Color>(
-                          monthlySales.achievementRate >= _baseRate
+                          monthlySales.achievementRate >= monthlySales.baseRate
                               ? AppColors.success
                               : AppColors.legacyDanger,
                         ),
@@ -191,7 +191,7 @@ class _MonthlySalesTabPageState extends ConsumerState<MonthlySalesTabPage> {
                 Align(
                   alignment: Alignment.centerRight,
                   child: Text(
-                    '기준 진도율 : ${_baseRate.toStringAsFixed(0)}%',
+                    '기준 진도율 : ${monthlySales.baseRate.toStringAsFixed(0)}%',
                     style: const TextStyle(
                         fontSize: 12, color: AppColors.legacyDanger),
                   ),
@@ -247,9 +247,6 @@ class _MonthlySalesTabPageState extends ConsumerState<MonthlySalesTabPage> {
       ),
     );
   }
-
-  /// 기준 진도율(영업일 기준). 신규 백엔드가 미제공이라 레거시 0% 상태와 동일하게 0 고정.
-  static const double _baseRate = 0;
 
   /// 원 → 만원 환산 (1만원 미만 절사) + 천단위 콤마. 레거시 list.jsp 단위 변환 정합.
   String _man(int won) =>

--- a/scripts/sf-data-migration/extract-csv.sh
+++ b/scripts/sf-data-migration/extract-csv.sh
@@ -54,7 +54,7 @@ set -euo pipefail
 SF_ORG=""
 SF_API_VERSION="60.0"
 OUT_DIR=""
-TARGETS="Organization,Account,Product,Promotion,Group,Employee,User,Notice,AccountCategoryMaster,AgreementHistory,AgreementWord,AlternativeHoliday,Appointment,AttendanceLog,AttendInfo,Claim,DisplayWorkSchedule,EmployeeInputCriteriaMaster,ErpOrder,ErpOrderProduct,HolidayMaster,InspectionTheme,SiteActivity,MonthlyFemaleEmployeeIntegrationSchedule,MonthlySalesHistory,DailySalesHistory,SalesProgressRateMaster,NewProduct,OrderRequest,OrderRequestProduct,ProductBarcode,ProfessionalPromotionTeamHistory,ProfessionalPromotionTeamMaster,PromotionEmployee,PromotionProduct,PushMessage,PushMessageReceiver,Suggestion,TeamMemberSchedule,UploadFile,UserRole,Profile,Permission"
+TARGETS="Organization,Account,Product,Promotion,Group,Employee,User,Notice,AccountCategoryMaster,AgreementHistory,AgreementWord,AlternativeHoliday,Appointment,AttendanceLog,AttendInfo,Claim,DisplayWorkSchedule,EmployeeInputCriteriaMaster,ErpOrder,ErpOrderProduct,HolidayMaster,WorkingDayMaster,InspectionTheme,SiteActivity,MonthlyFemaleEmployeeIntegrationSchedule,MonthlySalesHistory,DailySalesHistory,SalesProgressRateMaster,NewProduct,OrderRequest,OrderRequestProduct,ProductBarcode,ProfessionalPromotionTeamHistory,ProfessionalPromotionTeamMaster,PromotionEmployee,PromotionProduct,PushMessage,PushMessageReceiver,Suggestion,TeamMemberSchedule,UploadFile,UserRole,Profile,Permission"
 SKIP_GROUP_MEMBERS=0
 SKIP_VERIFY=0
 # spec #790 Q4 채택 — XML 메타 (extract-sharing-meta.sh) 자동 포함, --skip-sharing-meta 로 제외 가능
@@ -536,6 +536,14 @@ SELECT
     Id, HolidayDate__c, Name, Type__c, OwnerId,
     CreatedDate, LastModifiedDate, CreatedById, LastModifiedById, IsDeleted
 FROM HolidayMaster__c
+EOF
+)
+
+WORKING_DAY_MASTER_SOQL=$(cat <<'EOF'
+SELECT
+    Id, Name, WorkingDate__c, WorkingDateCheck__c, OwnerId,
+    CreatedDate, LastModifiedDate, CreatedById, LastModifiedById, IsDeleted
+FROM WorkingDayMaster__c
 EOF
 )
 
@@ -1131,6 +1139,10 @@ fi
 
 if contains_target "HolidayMaster"; then
     run_query "HolidayMaster (HolidayMaster__c)" "$HOLIDAY_MASTER_SOQL" "$OUT_DIR/holiday_masters.csv"
+fi
+
+if contains_target "WorkingDayMaster"; then
+    run_query "WorkingDayMaster (WorkingDayMaster__c)" "$WORKING_DAY_MASTER_SOQL" "$OUT_DIR/working_day_masters.csv"
 fi
 
 if contains_target "InspectionTheme"; then


### PR DESCRIPTION
레거시 heroku(월매출 list.jsp + SF Apex) 와 동일 로직으로 데이터가 나오도록 처리.

실적/목표 (마감 합계 실적 0 → 정상):
- customerId 키 회귀 수정: 모바일은 내부 account.id 를 보내는데 MonthlySalesService 만 이를 SAP 코드로 직접 취급해 매칭 실패였음 → LogisticsSalesService 와 동일하게 AccountRepository 로 resolve(id → externalKey) 후 SAP 코드로 RDS 조회.
- 목표: SalesProgressRateMaster(복제本) 의 (연,월) 1행으로 targetAmount(RT+FR+RM+FO)
  + 카테고리별 목표 + achievementRate(round(실적/목표×100)) 산출 — 기존 0 하드코딩 폐기. findByAccountIdAndTargetYear 추가(월은 정수 파싱 매칭).

기준 진도율 (baseRate, 레거시 calcBusinessRateOnlyThisMonth 정합):
- 응답 DTO 에 baseRate 추가. 당월일 때만 (월초~오늘 영업일)/(월초~월말 영업일)×100, 그 외 0.
- 영업일 source 를 레거시와 동일한 WorkingDayMaster(WorkingDateCheck=1) 로 정식 복제: Flyway working_day_master 테이블 + entity/repository + Stage1 타겟 + extract-csv.sh. 현재 SF 마스터가 비어 있어 0(레거시도 if(fromEndDayCnt<=0) return 0 으로 0) — 동등. SF 적재 시 코드 변경 없이 자동 정확.

모바일:
- MonthlySales entity/model 에 baseRate 추가, monthly_sales_tab_page 의 _baseRate=0 상수 제거하고 monthlySales.baseRate 사용.