### PR TITLE
feat(auth): access token TTL 단축·블랙리스트 Redis화 + 스플래시 버전 게이트

### DIFF
--- a/backend/src/main/kotlin/com/otoki/powersales/common/security/JwtTokenProvider.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/common/security/JwtTokenProvider.kt
@@ -8,9 +8,9 @@ import io.jsonwebtoken.security.Keys
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Component
+import java.security.MessageDigest
 import java.time.Duration
 import java.util.*
-import java.util.concurrent.ConcurrentHashMap
 import javax.crypto.SecretKey
 
 /**
@@ -28,9 +28,6 @@ class JwtTokenProvider(
     private val key: SecretKey by lazy {
         Keys.hmacShaKeyFor(secret.toByteArray())
     }
-
-    // Phase 1: 인메모리 블랙리스트 (Phase 2에서 Redis로 교체)
-    private val blacklist = ConcurrentHashMap<String, Date>()
 
     /**
      * Mobile (Employee 기반) Access Token 생성.
@@ -167,13 +164,20 @@ class JwtTokenProvider(
     }
 
     /**
-     * 토큰을 블랙리스트에 추가 (로그아웃 시 사용)
+     * 토큰을 블랙리스트에 추가 (로그아웃 시 사용).
+     *
+     * Redis에 `blacklist:<sha256(token)>` 키를 토큰 잔여 만료시간만큼 TTL로 저장한다.
+     * 다중 인스턴스 간 공유 + TTL 자동 정리. (구 인메모리 ConcurrentHashMap 대체)
      */
     fun blacklistToken(token: String) {
         try {
             val claims = parseClaims(token)
-            blacklist[token] = claims.expiration
-            cleanExpiredBlacklist()
+            val ttlMillis = claims.expiration.time - System.currentTimeMillis()
+            if (ttlMillis > 0) {
+                redisTemplate.opsForValue().set(
+                    "blacklist:${hashToken(token)}", "1", Duration.ofMillis(ttlMillis)
+                )
+            }
         } catch (e: ExpiredJwtException) {
             // 이미 만료된 토큰은 블랙리스트에 추가할 필요 없음
         }
@@ -258,7 +262,7 @@ class JwtTokenProvider(
     }
 
     private fun isBlacklisted(token: String): Boolean {
-        return blacklist.containsKey(token)
+        return redisTemplate.hasKey("blacklist:${hashToken(token)}") == true
     }
 
     private fun parseClaims(token: String): Claims {
@@ -269,12 +273,10 @@ class JwtTokenProvider(
             .payload
     }
 
-    /**
-     * 만료된 블랙리스트 항목 정리
-     */
-    private fun cleanExpiredBlacklist() {
-        val now = Date()
-        blacklist.entries.removeIf { it.value.before(now) }
+    /** 블랙리스트 Redis 키 길이를 제한하기 위해 토큰을 SHA-256 해시로 변환. */
+    private fun hashToken(token: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(token.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
     }
 
     companion object {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -97,8 +97,11 @@ management:
         enabled: true
 
 jwt:
+  # access: 1시간 (3600000ms). 짧게 유지해 폐기(revocation) 지연을 줄인다.
+  #   refresh 회전이 7일 롤링 세션을 유지하므로 사용자 체감 변화는 없다.
+  # refresh: 7일 (604800000ms). 회전 시 TTL 재부여되는 슬라이딩 윈도우 = 비활동 한계.
   secret: ${JWT_SECRET:otoki-internal-dev-secret-key-change-in-production-minimum-256-bits}
-  expiration: ${JWT_EXPIRATION:86400000}
+  expiration: ${JWT_EXPIRATION:3600000}
   refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
 
 orora:

--- a/backend/src/test/kotlin/com/otoki/powersales/common/security/JwtTokenProviderTest.kt
+++ b/backend/src/test/kotlin/com/otoki/powersales/common/security/JwtTokenProviderTest.kt
@@ -6,8 +6,11 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import io.mockk.every
 import io.mockk.mockk
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Duration
 
 /**
  * JwtTokenProvider 테스트
@@ -99,10 +102,18 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("validateToken은 블랙리스트에 추가된 토큰에 대해 false를 반환한다")
     fun validateToken_returnsFalse_forBlacklistedToken() {
-        // Given
+        // Given: Redis 블랙리스트를 in-memory set 으로 시뮬레이션 (set → 키 저장, hasKey → 존재 확인)
         val userId = 12345L
         val role = AppAuthority.WOMAN
         val token = jwtTokenProvider.createAccessToken(userId, role)
+
+        val blacklisted = mutableSetOf<String>()
+        val valueOps = mockk<ValueOperations<String, String>>(relaxed = true)
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { valueOps.set(any<String>(), any<String>(), any<Duration>()) } answers {
+            blacklisted.add(firstArg()); Unit
+        }
+        every { redisTemplate.hasKey(any<String>()) } answers { blacklisted.contains(firstArg()) }
 
         // When: 토큰을 블랙리스트에 추가
         jwtTokenProvider.blacklistToken(token)
@@ -229,10 +240,18 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("blacklistToken은 토큰을 블랙리스트에 추가하고 검증 시 실패한다")
     fun blacklistToken_addsTokenToBlacklist() {
-        // Given
+        // Given: Redis 블랙리스트를 in-memory set 으로 시뮬레이션
         val userId = 12345L
         val role = AppAuthority.WOMAN
         val token = jwtTokenProvider.createAccessToken(userId, role)
+
+        val blacklisted = mutableSetOf<String>()
+        val valueOps = mockk<ValueOperations<String, String>>(relaxed = true)
+        every { redisTemplate.opsForValue() } returns valueOps
+        every { valueOps.set(any<String>(), any<String>(), any<Duration>()) } answers {
+            blacklisted.add(firstArg()); Unit
+        }
+        every { redisTemplate.hasKey(any<String>()) } answers { blacklisted.contains(firstArg()) }
 
         // When: 처음에는 유효
         assertTrue(jwtTokenProvider.validateToken(token))

--- a/mobile/lib/app_router.dart
+++ b/mobile/lib/app_router.dart
@@ -52,12 +52,14 @@ import 'presentation/screens/login_screen.dart';
 import 'presentation/screens/main_screen.dart';
 import 'presentation/screens/pos_sales_screen.dart';
 import 'presentation/screens/sales_overview_screen.dart';
+import 'presentation/screens/splash_screen.dart';
 
 /// 앱 라우터
 ///
 /// 앱 전체의 라우팅을 관리합니다.
 class AppRouter {
   /// 라우트 이름 상수
+  static const String splash = '/splash';
   static const String login = '/login';
   static const String changePassword = '/change-password';
   static const String verifyPassword = '/verify-password'; // F54: 현재 비밀번호 확인
@@ -113,6 +115,7 @@ class AppRouter {
 
   /// 라우트 맵
   static Map<String, WidgetBuilder> get routes => {
+        splash: (context) => const SplashScreen(),
         login: (context) => const LoginScreen(),
         changePassword: (context) => const ChangePasswordScreen(),
         gpsConsent: (context) => const GpsConsentScreen(), // F62: GPS 동의
@@ -252,8 +255,8 @@ class AppRouter {
         },
       };
 
-  /// 초기 라우트 - 로그인 화면에서 시작
-  static String get initialRoute => login;
+  /// 초기 라우트 - 스플래시(버전 게이트 + 자동 로그인)에서 시작
+  static String get initialRoute => splash;
 
   /// 알 수 없는 라우트 처리
   static Route<dynamic>? onUnknownRoute(RouteSettings settings) {

--- a/mobile/lib/core/services/app_version_checker.dart
+++ b/mobile/lib/core/services/app_version_checker.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../network/dio_provider.dart';
+import '../../data/datasources/app_version_api_datasource.dart';
+
+/// 앱 버전 게이트 체커.
+///
+/// 현재 플랫폼/버전을 해석해 서버 버전 정책과 비교한다.
+/// - 미지원 플랫폼(web/desktop)이거나 호출 실패 시 null 반환 → 게이트 skip(fail-open).
+///   버전 체크 실패가 앱 진입을 막아선 안 된다.
+class AppVersionChecker {
+  final AppVersionApiDataSource _api;
+
+  AppVersionChecker(this._api);
+
+  Future<AppVersionResult?> check() async {
+    // 백엔드 AppPlatform enum 값(대문자).
+    final String platform;
+    if (Platform.isAndroid) {
+      platform = 'ANDROID';
+    } else if (Platform.isIOS) {
+      platform = 'IOS';
+    } else {
+      return null;
+    }
+
+    try {
+      final info = await PackageInfo.fromPlatform();
+      // buildNumber(문자열)를 versionCode(Long)로 변환. 파싱 불가 시 게이트 skip.
+      final versionCode = int.tryParse(info.buildNumber);
+      if (versionCode == null) return null;
+      return await _api.check(platform: platform, versionCode: versionCode);
+    } catch (_) {
+      // 네트워크/파싱 실패 → 게이트 skip
+      return null;
+    }
+  }
+}
+
+final appVersionApiDataSourceProvider = Provider<AppVersionApiDataSource>((ref) {
+  return AppVersionApiDataSource(ref.watch(dioProvider));
+});
+
+final appVersionCheckerProvider = Provider<AppVersionChecker>((ref) {
+  return AppVersionChecker(ref.watch(appVersionApiDataSourceProvider));
+});

--- a/mobile/lib/data/datasources/app_version_api_datasource.dart
+++ b/mobile/lib/data/datasources/app_version_api_datasource.dart
@@ -1,0 +1,63 @@
+import 'package:dio/dio.dart';
+
+/// 앱 버전 체크 API 응답 (백엔드 `AppVersionCheckDto`).
+class AppVersionResult {
+  /// 최신 versionCode 가 현재보다 큼 (권장 업데이트).
+  final bool updateAvailable;
+
+  /// 현재 버전 초과~최신 사이에 강제 버전 존재 (강제 업데이트, 진입 차단).
+  final bool forceUpdate;
+
+  /// 최신 버전 이름 (예: "1.2.3").
+  final String? latestVersionName;
+
+  /// 릴리스 노트.
+  final String? releaseNote;
+
+  /// 다운로드 URL — Android=APK presigned URL, iOS=`itms-services://...` (미설정 시 null).
+  final String? downloadUrl;
+
+  const AppVersionResult({
+    required this.updateAvailable,
+    required this.forceUpdate,
+    this.latestVersionName,
+    this.releaseNote,
+    this.downloadUrl,
+  });
+
+  factory AppVersionResult.fromJson(Map<String, dynamic> json) {
+    return AppVersionResult(
+      updateAvailable: json['updateAvailable'] as bool? ?? false,
+      forceUpdate: json['forceUpdate'] as bool? ?? false,
+      latestVersionName: json['latestVersionName'] as String?,
+      releaseNote: json['releaseNote'] as String?,
+      downloadUrl: json['downloadUrl'] as String?,
+    );
+  }
+}
+
+/// 앱 패키지 버전 체크 API 데이터소스.
+///
+/// 백엔드: `GET /api/v1/mobile/app-package/check` (인증 불필요 — 스플래시에서 로그인 전 호출).
+class AppVersionApiDataSource {
+  final Dio _dio;
+
+  AppVersionApiDataSource(this._dio);
+
+  /// [platform] 은 백엔드 `AppPlatform` enum 값(`ANDROID`/`IOS`).
+  /// [versionCode] 는 현재 앱 빌드 번호(Long).
+  Future<AppVersionResult> check({
+    required String platform,
+    required int versionCode,
+  }) async {
+    final response = await _dio.get(
+      '/api/v1/mobile/app-package/check',
+      queryParameters: {
+        'platform': platform,
+        'versionCode': versionCode,
+      },
+    );
+    final data = response.data['data'] as Map<String, dynamic>;
+    return AppVersionResult.fromJson(data);
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -57,10 +57,9 @@ class _OtokiAppState extends ConsumerState<OtokiApp>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    // 앱 시작 시 인증 초기화 (저장된 사번 로드 + 자동 로그인 시도)
+    // 인증 초기화(자동 로그인)는 SplashScreen 이 버전 게이트 통과 후 호출한다.
+    // 여기서는 게이트와 무관한 FCM 초기화만 수행한다.
     Future.microtask(() {
-      ref.read(authProvider.notifier).initialize();
-
       // FCM 권한 요청 + 토큰/리스너 등록 (설정 파일 없으면 내부에서 skip)
       final push = ref.read(pushNotificationServiceProvider);
       push.initialize();

--- a/mobile/lib/presentation/screens/splash_screen.dart
+++ b/mobile/lib/presentation/screens/splash_screen.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/services/app_version_checker.dart';
+import '../../core/theme/app_colors.dart';
+import '../../data/datasources/app_version_api_datasource.dart';
+import '../providers/auth_provider.dart';
+
+/// 앱 시작 스플래시 화면.
+///
+/// 순서: ① 버전 게이트(강제 업데이트면 진입 차단) → ② 자동 로그인 초기화.
+/// 자동 로그인이 끝나면 main.dart 의 authProvider 리스너가 적절한 화면으로 전환한다.
+/// (인증 상태 resolve 전까지는 이 화면이 유지된다)
+class SplashScreen extends ConsumerStatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  ConsumerState<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends ConsumerState<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // 첫 프레임 이후 실행 — context/navigator 준비 보장.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
+  }
+
+  Future<void> _bootstrap() async {
+    final result = await ref.read(appVersionCheckerProvider).check();
+
+    // 강제 업데이트 → 진입 차단 (자동 로그인 시작하지 않음)
+    if (result != null && result.forceUpdate) {
+      await _showForceUpdateDialog(result);
+      return;
+    }
+
+    // 권장 업데이트 → 안내 후 계속 진행
+    if (result != null && result.updateAvailable) {
+      await _showOptionalUpdateDialog(result);
+    }
+
+    if (!mounted) return;
+    // 자동 로그인 초기화 (이후 main.dart 리스너가 화면 전환)
+    ref.read(authProvider.notifier).initialize();
+  }
+
+  Future<void> _openDownload(String? downloadUrl) async {
+    if (downloadUrl == null || downloadUrl.isEmpty) return;
+    final uri = Uri.tryParse(downloadUrl);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _showForceUpdateDialog(AppVersionResult result) async {
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => PopScope(
+        canPop: false,
+        child: AlertDialog(
+          title: const Text('업데이트가 필요합니다'),
+          content: Text(
+            result.releaseNote?.isNotEmpty == true
+                ? result.releaseNote!
+                : '원활한 사용을 위해 최신 버전으로 업데이트해 주세요.\n'
+                    '업데이트 후 다시 실행해 주세요.',
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () => _openDownload(result.downloadUrl),
+              child: const Text('업데이트하기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showOptionalUpdateDialog(AppVersionResult result) async {
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('업데이트 안내'),
+        content: Text(
+          result.latestVersionName != null
+              ? '새로운 버전(${result.latestVersionName})이 있습니다.'
+              : '새로운 버전이 있습니다.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('나중에'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              _openDownload(result.downloadUrl);
+            },
+            child: const Text('업데이트'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            Text(
+              '오뚜기 임직원 영업관리',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: AppColors.secondary,
+              ),
+            ),
+            SizedBox(height: 32),
+            // 빈 화면 금지 원칙 — 로딩 상태를 네이비 스피너로 가시화
+            CircularProgressIndicator(
+              color: AppColors.secondary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/app_router_test.dart
+++ b/mobile/test/app_router_test.dart
@@ -9,9 +9,14 @@ void main() {
   });
 
   group('AppRouter', () {
-    test('초기 라우트가 로그인 경로이다', () {
-      expect(AppRouter.initialRoute, AppRouter.login);
-      expect(AppRouter.initialRoute, '/login');
+    test('초기 라우트가 스플래시 경로이다', () {
+      expect(AppRouter.initialRoute, AppRouter.splash);
+      expect(AppRouter.initialRoute, '/splash');
+    });
+
+    test('스플래시 라우트가 routes 맵에 존재한다', () {
+      final routes = AppRouter.routes;
+      expect(routes.containsKey(AppRouter.splash), true);
     });
 
     // MainScreen 내부의 HomePage가 initState에서 addPostFrameCallback으로
@@ -107,7 +112,8 @@ void main() {
       expect(routes.containsKey(AppRouter.gpsConsent), true);
       expect(routes.containsKey(AppRouter.suggestionRegister), true);
       expect(routes.containsKey(AppRouter.safetyCheckStatus), true);
-      expect(routes.length, 51);
+      expect(routes.containsKey(AppRouter.splash), true);
+      expect(routes.length, 52);
     });
 
     test('routes 맵에 orderList 라우트가 포함되어 있다', () {


### PR DESCRIPTION
세션 관리 점검에 따른 P1 보안 강화 + 스플래시 버전 게이트(P2).

P1 (보안 — 폐기 지연 축소):
- jwt.expiration 24h(86400000)→1h(3600000). refresh 7일 롤링은 유지되어 사용자 체감 변화 없이 토큰 폐기 지연만 단축.
- 로그아웃 블랙리스트를 인메모리 ConcurrentHashMap→Redis(blacklist:<sha256>)로 이전, 다중 인스턴스 간 공유 + TTL 자동 정리.

P2 (스플래시 버전 게이트, 모바일):
- SplashScreen 신설(initialRoute=splash). 버전 게이트(강제 시 진입 차단) 통과 후 자동 로그인 initialize() 호출. 체크 실패 시 fail-open.
- 버전 체크는 기존 백엔드 GET /api/v1/mobile/app-package/check (DB 기반 app-package 시스템)를 호출. platform(ANDROID/IOS)+versionCode(buildNumber)로 조회, forceUpdate/updateAvailable 분기, downloadUrl(APK/itms-services)로 업데이트 유도.