### PR TITLE
fix(inspection): 현장점검 테마 표시·생성·메뉴 레거시 정합

### DIFF
--- a/backend/src/main/kotlin/com/otoki/powersales/inspection/dto/response/ThemeResponse.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/inspection/dto/response/ThemeResponse.kt
@@ -7,15 +7,24 @@ import com.otoki.powersales.inspection.entity.InspectionTheme
  */
 data class ThemeResponse(
     val id: Long,
+    /**
+     * 화면 표시명. 레거시(fieldTalk write.jsp) 의 `title__c [department__c]` 표시 정합.
+     * 엔티티 `name` 은 테마번호(TM00000001 코드)이므로 표시에 쓰지 않고, 테마명(title)에
+     * 부서(department)를 덧붙여 내려준다. 제출은 id 로만 하므로 코드값은 노출 불필요.
+     */
     val name: String,
     val startDate: String,
     val endDate: String
 ) {
     companion object {
         fun from(theme: InspectionTheme): ThemeResponse {
+            val title = theme.title ?: ""
+            val department = theme.department
+            val displayName =
+                if (!department.isNullOrBlank()) "$title [$department]" else title
             return ThemeResponse(
                 id = theme.id,
-                name = theme.name ?: "",
+                name = displayName,
                 startDate = theme.startDate?.toString() ?: "",
                 endDate = theme.endDate?.toString() ?: ""
             )

--- a/backend/src/main/kotlin/com/otoki/powersales/inspection/service/AdminInspectionThemeService.kt
+++ b/backend/src/main/kotlin/com/otoki/powersales/inspection/service/AdminInspectionThemeService.kt
@@ -141,7 +141,8 @@ class AdminInspectionThemeService(
             endDate = request.endDate?.let { LocalDate.parse(it) },
             department = employee.orgName,
             branchCode = employee.costCenterCode,
-            publicFlag = true,
+            // 레거시 Theme__c.PublicFlag__c 기본값 정합(입력란 없이 false 생성). 조회 필터엔 미사용.
+            publicFlag = false,
             isDeleted = false,
         )
         val saved = inspectionThemeRepository.save(theme)

--- a/web/src/config/menuConfig.tsx
+++ b/web/src/config/menuConfig.tsx
@@ -271,8 +271,8 @@ export const menuRoute: MenuRoute = {
       name: '현장 점검/이슈',
       icon: <SearchOutlined />,
       children: [
+        { path: '/inspection-themes', name: '현장점검 테마 관리', entity: 'inspection_theme', operation: 'READ' },
         { path: '/field-inspection', name: '현장점검', entity: 'site_activity', operation: 'READ' },
-        { path: '/inspection-themes', name: '현장점검 등록', entity: 'inspection_theme', operation: 'READ' },
         { path: '/safety-check', name: '안전점검', entity: 'team_member_schedule', operation: 'READ' },
         { path: '/product-expiration', name: '유통기한 관리', entity: 'product', operation: 'READ' },
         {


### PR DESCRIPTION
- 테마 응답명을 테마번호(코드) 대신 `테마명 [부서]`로 표시(레거시 title__c [department__c] 정합)
- 테마 생성 시 publicFlag 기본값 true→false(레거시 PublicFlag__c 정합, 조회 필터 미사용)
- 웹 메뉴 "현장점검 등록"→"현장점검 테마 관리"로 명확화, 현장점검보다 앞 노출