### PR TITLE
fix(mobile): 조장뷰 권한 분기를 레거시 eq '조장' 정확 일치로 정합

### DIFF
--- a/mobile/lib/core/constants/menu_constants.dart
+++ b/mobile/lib/core/constants/menu_constants.dart
@@ -123,10 +123,11 @@ abstract final class MenuConstants {
     ),
   ];
 
-  /// 조장/지점장 전용: "여사원 관리" 메뉴 그룹
+  /// 조장 전용: "여사원 관리" 메뉴 그룹
   ///
-  /// FullMenuDrawer에서 user.role이 LEADER 또는 ADMIN일 때
-  /// "거래처" 그룹 다음 위치에 삽입한다.
+  /// FullMenuDrawer에서 user.role이 LEADER(조장)일 때만
+  /// "거래처" 그룹 다음 위치에 삽입한다. 레거시 GNB(gnb.jsp) nav7 조건이
+  /// `eq '조장'` 정확 일치이므로 지점장/부서장에게는 노출하지 않는다.
   ///
   /// 레거시 Heroku GNB "여사원 관리" 그룹 정합(gnb.jsp): 항목은 "여사원"(/employee/main)
   /// 과 "일정 / 등록"(/employee/mgnSchedule) 2개뿐이다. "일정 / 등록"은 월간 캘린더

--- a/mobile/lib/presentation/pages/home_page.dart
+++ b/mobile/lib/presentation/pages/home_page.dart
@@ -305,8 +305,10 @@ class _HomePageState extends ConsumerState<HomePage>
 
   /// 등록 버튼 탭 핸들러: 조장이면 바로 출근등록, 그 외 안전점검 상태 확인 후 분기
   Future<void> _handleRegisterTap(String userRole) async {
-    // 조장(LEADER)/지점장(ADMIN)은 안전점검 없이 바로 출근등록
-    if (userRole == 'LEADER' || userRole == 'ADMIN') {
+    // 조장(LEADER)만 안전점검 없이 바로 출근등록.
+    // 레거시 home.jsp 는 조장만 safetyCheck 미세팅(바로 출근)이고, 지점장/부서장은
+    // else 분기에서 safetyCheck 가 세팅되어 여사원과 동일하게 안전점검을 선행한다.
+    if (userRole == 'LEADER') {
       await AppRouter.navigateTo(context, AppRouter.attendance);
       return;
     }
@@ -337,7 +339,9 @@ class _HomePageState extends ConsumerState<HomePage>
 
   /// 빠른 메뉴 탭 핸들러
   void _handleQuickMenuTap(QuickMenuItem item, String userRole) {
-    final isLeaderOrAdmin = userRole == 'LEADER' || userRole == 'ADMIN';
+    // 레거시 home.jsp JS 의 행사매출 차단 조건이 `== '조장'` 정확 일치이므로,
+    // 조장(LEADER)만 차단하고 지점장/부서장은 여사원과 동일하게 등록을 허용한다.
+    final isLeader = userRole == 'LEADER';
 
     if (item.label == '활동 등록') {
       ActivityRegistrationPopup.show(
@@ -345,7 +349,7 @@ class _HomePageState extends ConsumerState<HomePage>
         onMenuTap: _handleActivityMenuTap,
       );
     } else if (item.label == '행사매출\n등록') {
-      if (isLeaderOrAdmin) {
+      if (isLeader) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('행사 담당자만 행사매출을 등록할 수 있습니다.'),

--- a/mobile/lib/presentation/widgets/home/schedule_card.dart
+++ b/mobile/lib/presentation/widgets/home/schedule_card.dart
@@ -12,9 +12,11 @@ import '../../../domain/entities/schedule.dart';
 /// - 일정 있음: 오늘 스케줄 목록 (근무유형 배지, 매장명, 출근 상태)
 /// - 출근 카운트 배지: "✓ X/N" 형태로 출근 현황 표시
 ///
-/// 조장(LEADER)/지점장(ADMIN) 뷰 (레거시 home.jsp 정합):
+/// 조장(LEADER) 뷰 (레거시 home.jsp 정합):
 /// - 날짜 → "N명 중, M명 등록 완료" → 풀폭 "일정 관리" navy 버튼
 /// - 팀원 목록/등록 버튼 미표시 (팀원 상세는 "일정 관리" 진입 후 페이지에서 확인)
+/// - 레거시 home.jsp:509 근태영역 조건이 `eq '조장'` 정확 일치이므로 지점장(ADMIN)·
+///   부서장(USER)은 조장뷰가 아닌 본인 일정 뷰로 떨어진다.
 class ScheduleCard extends StatelessWidget {
   /// 오늘 일정 목록
   final List<Schedule> schedules;
@@ -51,8 +53,8 @@ class ScheduleCard extends StatelessWidget {
     this.onScheduleManageTap,
   });
 
-  /// 조장/지점장 뷰 여부
-  bool get _isLeaderView => userRole == 'LEADER' || userRole == 'ADMIN';
+  /// 조장 뷰 여부 (레거시 `eq '조장'` 정확 일치 — 지점장/부서장 제외)
+  bool get _isLeaderView => userRole == 'LEADER';
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/presentation/widgets/menu/full_menu_drawer.dart
+++ b/mobile/lib/presentation/widgets/menu/full_menu_drawer.dart
@@ -76,7 +76,7 @@ class FullMenuDrawer extends ConsumerWidget {
                 child: SingleChildScrollView(
                   child: Column(
                     children: [
-                      // 메뉴 그룹 목록 (조장/지점장은 "거래처" 다음에 "여사원 관리" 삽입)
+                      // 메뉴 그룹 목록 (조장은 "거래처" 다음에 "여사원 관리" 삽입)
                       ..._buildMenuGroups(context, user?.role),
                       // 메뉴 가장 하단에 현재 버전 표시 (메뉴와 함께 스크롤)
                       const _MenuVersionFooter(),
@@ -93,15 +93,17 @@ class FullMenuDrawer extends ConsumerWidget {
 
   /// 메뉴 그룹 위젯 목록 생성
   ///
-  /// LEADER/ADMIN일 때 "거래처" 그룹 다음에 "여사원 관리" 그룹을 삽입한다.
+  /// 조장(LEADER)일 때만 "거래처" 그룹 다음에 "여사원 관리" 그룹을 삽입한다.
+  /// 레거시 GNB(gnb.jsp:212-218) nav7 조건이 `eq '조장'` 정확 일치이므로,
+  /// 지점장(ADMIN)·부서장(AccountViewAll)에게는 노출하지 않는다.
   List<Widget> _buildMenuGroups(BuildContext context, String? role) {
-    final isLeaderOrAdmin = role == 'LEADER' || role == 'ADMIN';
+    final isLeader = role == 'LEADER';
 
     // 조건부 삽입할 그룹 목록 구성
     final groups = <domain.MenuGroup>[];
     for (final group in MenuConstants.menuGroups) {
       groups.add(group);
-      if (isLeaderOrAdmin && group.id == 'trade') {
+      if (isLeader && group.id == 'trade') {
         groups.add(MenuConstants.teamManagementGroup);
       }
     }

--- a/mobile/lib/presentation/widgets/promotion/promotion_list_view.dart
+++ b/mobile/lib/presentation/widgets/promotion/promotion_list_view.dart
@@ -21,7 +21,9 @@ import 'promotion_card.dart';
 ///
 /// 레거시(heroku `promotion/event/list.jsp`) 정합:
 /// - 거래처 전체 드롭다운 + 기간 + 검색 버튼 (버튼 트리거 검색)
-/// - 권한 분기: 여사원(member)은 단일 날짜, 조장/지점장(leader)은 기간 범위 + 행사명 검색어
+/// - 권한 분기: 여사원(member)은 단일 날짜, 조장(leader)은 기간 범위 + 행사명 검색어.
+///   레거시 list.jsp:9-11 의 조건이 `eq member`/`eq leader` 정확 일치이므로
+///   지점장/부서장은 조장형이 아닌 여사원형(단일 날짜) 필터로 떨어진다.
 /// - "내 행사 현황 (N)" 카운트 헤더
 class PromotionListView extends ConsumerStatefulWidget {
   const PromotionListView({super.key});
@@ -51,14 +53,15 @@ class _PromotionListViewState extends ConsumerState<PromotionListView>
     super.dispose();
   }
 
-  /// 현재 사용자가 조장/지점장(leader) 권한인지 여부.
+  /// 현재 사용자가 조장(leader) 권한인지 여부.
   ///
   /// 레거시는 `appauthority__c` 가 `조장`(group_leader) 이면 기간 범위 + 행사명 검색,
-  /// `여사원`(group_member) 이면 단일 날짜 + 검색 버튼만 노출한다.
-  /// 모바일 도메인 role 은 `여사원→USER`, `조장→LEADER`, `지점장→ADMIN` 로 번역된다.
+  /// `여사원`(group_member) 이면 단일 날짜 + 검색 버튼만 노출한다(list.jsp:9-11 정확 일치).
+  /// 지점장/부서장은 두 조건 어디에도 해당하지 않아 여사원형 필터로 폴백한다.
+  /// 모바일 도메인 role 은 `여사원→USER`, `조장→LEADER`, `지점장→ADMIN`, `부서장→USER` 로 번역된다.
   bool get _isLeader {
     final role = ref.read(authProvider).user?.role;
-    return role == 'LEADER' || role == 'ADMIN';
+    return role == 'LEADER';
   }
 
   void _onScroll() {


### PR DESCRIPTION
지점장(ADMIN)을 조장 취급하던 LEADER||ADMIN 분기를 모두 LEADER 전용으로 좁힘. 레거시 Heroku(gnb.jsp/home.jsp/event list.jsp)는 권한 분기가 전부 appauthority__c eq '조장' 정확 일치라 지점장/부서장은 조장뷰에서 제외된다. 지점장/부서장은 빈 화면 금지 원칙상 여사원형(본인) 뷰로 폴백.

- 드로워 「여사원 관리」 메뉴: 조장만 노출
- 홈 팀 출근현황 뷰 + 안전점검 스킵 + 행사매출 등록 차단: 조장만
- 행사 목록 기간범위+행사명 필터: 조장만

행사 목록 거래처 스코프(field)는 백엔드 MyAccountService에서 이미
레거시 eventList(부서장 본인 거래처)와 정합이라 변경 없음.